### PR TITLE
refactor smart object explorer

### DIFF
--- a/packages/components/built/SmartObject.js
+++ b/packages/components/built/SmartObject.js
@@ -73,7 +73,7 @@ var SmartObjectValues = function (_a) {
         })
             .map(function (_a, i) {
             var key = _a[0], value = _a[1];
-            return (_jsxs("div", { children: [_jsx("h3", { className: "mt-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(key) }), _jsx(ObjectValueCard, { id: key, content: toObject(value || '') })] }, i));
+            return (_jsxs("div", { children: [_jsx("h3", { className: "mt-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(key) }), _jsx(ObjectValueCard, { id: key, content: toObject(value) })] }, i));
         }) }));
 };
 function MetaData(_a) {

--- a/packages/components/built/SmartObject.js
+++ b/packages/components/built/SmartObject.js
@@ -43,7 +43,7 @@ import { capitalizeFirstLetter, toObject } from './common/utils';
 import { Card } from './Card';
 import { Modal } from './Modal';
 import { FunctionResultModalContent } from './common/SmartCallExecutionResult';
-import { SmartObjectFunction } from './SmartObjectFunction';
+import { SmartObjectFunctions } from './SmartObjectFunctions';
 import { ComputerContext } from './ComputerContext';
 var keywords = ['_id', '_rev', '_owners', '_root', '_amount'];
 var modalId = 'smart-object-info-modal';
@@ -164,7 +164,7 @@ function Component(_a) {
         setFunctionsExist(funcExist);
     }, [smartObject]);
     var _h = rev.split(':'), txId = _h[0], outNum = _h[1];
-    return (_jsxs(_Fragment, { children: [_jsxs("div", { className: "max-w-screen-md mx-auto", children: [_jsx("h1", { className: "mb-2 text-5xl font-extrabold dark:text-white", children: title || 'Object' }), _jsxs("div", { className: "mb-8", children: [_jsx(Link, { to: "/transactions/".concat(txId), className: "font-medium text-blue-600 dark:text-blue-500 hover:underline", children: txId }), _jsxs("span", { children: [":", outNum] }), _jsx(Copy, { text: "".concat(txId, ":").concat(outNum) })] }), _jsx(SmartObjectValues, { smartObject: smartObject }), _jsx(SmartObjectFunction, { smartObject: smartObject, functionsExist: functionsExist, options: options, setFunctionResult: setFunctionResult, setShow: setShow, setModalTitle: setModalTitle }), _jsx(MetaData, { smartObject: smartObject, prev: prev, next: next })] }), _jsx(Modal.Component, { title: modalTitle, content: FunctionResultModalContent, contentData: { functionResult: functionResult }, id: modalId })] }));
+    return (_jsxs(_Fragment, { children: [_jsxs("div", { className: "max-w-screen-md mx-auto", children: [_jsx("h1", { className: "mb-2 text-5xl font-extrabold dark:text-white", children: title || 'Object' }), _jsxs("div", { className: "mb-8", children: [_jsx(Link, { to: "/transactions/".concat(txId), className: "font-medium text-blue-600 dark:text-blue-500 hover:underline", children: txId }), _jsxs("span", { children: [":", outNum] }), _jsx(Copy, { text: "".concat(txId, ":").concat(outNum) })] }), _jsx(SmartObjectValues, { smartObject: smartObject }), _jsx(SmartObjectFunctions, { smartObject: smartObject, functionsExist: functionsExist, options: options, setFunctionResult: setFunctionResult, setShow: setShow, setModalTitle: setModalTitle }), _jsx(MetaData, { smartObject: smartObject, prev: prev, next: next })] }), _jsx(Modal.Component, { title: modalTitle, content: FunctionResultModalContent, contentData: { functionResult: functionResult }, id: modalId })] }));
 }
 export var SmartObject = {
     Component: Component,

--- a/packages/components/built/SmartObjectFunction.d.ts
+++ b/packages/components/built/SmartObjectFunction.d.ts
@@ -1,6 +1,5 @@
 export declare const getErrorMessage: (error: any) => string;
 export declare const getFnParamNames: (fn: string) => string[];
-export declare const getValueForType: (type: string, stringValue: string) => string | number | true | null | undefined;
 export declare const SmartObjectFunction: ({ smartObject, functionsExist, options, setFunctionResult, setShow, setModalTitle, funcName, }: {
     smartObject: any;
     functionsExist: boolean;

--- a/packages/components/built/SmartObjectFunction.d.ts
+++ b/packages/components/built/SmartObjectFunction.d.ts
@@ -1,5 +1,5 @@
 export declare const getErrorMessage: (error: any) => string;
-export declare const getFnParamNames: (fn: string) => string[];
+export declare const getParameterNames: (fn: string) => string[];
 export declare const SmartObjectFunction: ({ smartObject, functionsExist, options, setFunctionResult, setShow, setModalTitle, funcName, }: {
     smartObject: any;
     functionsExist: boolean;

--- a/packages/components/built/SmartObjectFunction.d.ts
+++ b/packages/components/built/SmartObjectFunction.d.ts
@@ -1,4 +1,12 @@
 export declare const getErrorMessage: (error: any) => string;
 export declare const getFnParamNames: (fn: string) => string[];
 export declare const getValueForType: (type: string, stringValue: string) => string | number | true | null | undefined;
-export declare const SmartObjectFunction: ({ smartObject, functionsExist, options, setFunctionResult, setShow, setModalTitle, }: any) => import("react/jsx-runtime").JSX.Element;
+export declare const SmartObjectFunction: ({ smartObject, functionsExist, options, setFunctionResult, setShow, setModalTitle, funcName, }: {
+    smartObject: any;
+    functionsExist: boolean;
+    options: string[];
+    setFunctionResult: React.Dispatch<any>;
+    setShow: any;
+    setModalTitle: React.Dispatch<React.SetStateAction<string>>;
+    funcName: string;
+}) => import("react/jsx-runtime").JSX.Element;

--- a/packages/components/built/SmartObjectFunction.js
+++ b/packages/components/built/SmartObjectFunction.js
@@ -46,7 +46,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 import { Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
-import { useContext, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import { TypeSelectionDropdown } from './common/TypeSelectionDropdown';
 import { isValidRev, sleep } from './common/utils';
 import { UtilsContext } from './UtilsContext';
@@ -85,8 +85,13 @@ export var getValueForType = function (type, stringValue) {
     }
 };
 export var SmartObjectFunction = function (_a) {
-    var smartObject = _a.smartObject, functionsExist = _a.functionsExist, options = _a.options, setFunctionResult = _a.setFunctionResult, setShow = _a.setShow, setModalTitle = _a.setModalTitle;
-    var _b = useState({}), formState = _b[0], setFormState = _b[1];
+    var smartObject = _a.smartObject, functionsExist = _a.functionsExist, options = _a.options, setFunctionResult = _a.setFunctionResult, setShow = _a.setShow, setModalTitle = _a.setModalTitle, funcName = _a.funcName;
+    var paramList = getFnParamNames(Object.getPrototypeOf(smartObject)[funcName]).filter(function (val) { return val; });
+    var _b = useState(Object.fromEntries(paramList.flatMap(function (key) { return [
+        ["".concat(funcName, "-").concat(key), ''],
+        ["".concat(funcName, "-").concat(key, "--types"), ''],
+    ]; }))), formState = _b[0], setFormState = _b[1];
+    console.log('testing: ', funcName, Object.keys(formState).length > 0 && Object.values(formState).every(function (value) { return value === ''; }), formState);
     var showLoader = UtilsContext.useUtilsComponents().showLoader;
     var computer = useContext(ComputerContext);
     var handleSmartObjectMethod = function (event, smartObj, fnName, params) { return __awaiter(void 0, void 0, void 0, function () {
@@ -163,16 +168,12 @@ export var SmartObjectFunction = function (_a) {
         setFormState(value);
     };
     var capitalizeFirstLetter = function (s) { return s.charAt(0).toUpperCase() + s.slice(1); };
+    var isCallDisabled = useMemo(function () {
+        return Object.keys(formState).length > 0 && Object.values(formState).some(function (value) { return value === ''; });
+    }, [formState]);
     if (!functionsExist)
         return _jsx(_Fragment, {});
-    return (_jsx(_Fragment, { children: Object.getOwnPropertyNames(Object.getPrototypeOf(smartObject))
-            .filter(function (key) {
-            return key !== 'constructor' && typeof Object.getPrototypeOf(smartObject)[key] === 'function';
-        })
-            .map(function (key, fnIndex) {
-            var paramList = getFnParamNames(Object.getPrototypeOf(smartObject)[key]);
-            return (_jsxs("div", { className: "mt-6 mb-6", id: "function-".concat(key), children: [_jsx("h3", { className: "my-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(key) }), _jsxs("form", { id: "fn-index-".concat(fnIndex), children: [paramList.map(function (paramName, paramIndex) { return (_jsx("div", { className: "mb-4", children: _jsxs("div", { className: "flex items-center space-x-4", children: [_jsx("input", { type: "text", id: "".concat(key, "-").concat(paramName), value: formState["".concat(key, "-").concat(paramName)] || '', onChange: function (e) { return updateFormValue(e, "".concat(key, "-").concat(paramName)); }, className: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: paramName, required: true }), _jsx(TypeSelectionDropdown, { id: "".concat(key).concat(paramName), dropdownList: options, onSelectMethod: function (option) {
-                                                return updateTypes(option, "".concat(key, "-").concat(paramName));
-                                            } })] }) }, paramIndex)); }), _jsx("button", { id: "".concat(key, "-call-function-button"), className: "text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700", onClick: function (evt) { return handleSmartObjectMethod(evt, smartObject, key, paramList); }, children: "Call Function" })] })] }, fnIndex));
-        }) }));
+    return (_jsx(_Fragment, { children: _jsxs("div", { className: "mt-6 mb-6", id: "function-".concat(funcName), children: [_jsx("h3", { className: "my-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(funcName) }), _jsxs("form", { children: [paramList.map(function (paramName, paramIndex) { return (_jsx("div", { className: "mb-4", children: _jsxs("div", { className: "flex items-center space-x-4", children: [_jsx("input", { type: "text", id: "".concat(funcName, "-").concat(paramName), value: formState["".concat(funcName, "-").concat(paramName)] || '', onChange: function (e) { return updateFormValue(e, "".concat(funcName, "-").concat(paramName)); }, className: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: paramName, required: true }), _jsx(TypeSelectionDropdown, { id: "".concat(funcName).concat(paramName), dropdownList: options, onSelectMethod: function (option) {
+                                            return updateTypes(option, "".concat(funcName, "-").concat(paramName));
+                                        } })] }) }, paramIndex)); }), _jsx("button", { id: "".concat(funcName, "-call-function-button"), disabled: isCallDisabled, className: "text-white font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 focus:ring-4 focus:outline-none\n              ".concat(isCallDisabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-700 hover:bg-blue-800 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800', "\n            "), onClick: function (evt) { return handleSmartObjectMethod(evt, smartObject, funcName, paramList); }, children: "Call Function" })] })] }) }));
 };

--- a/packages/components/built/SmartObjectFunction.js
+++ b/packages/components/built/SmartObjectFunction.js
@@ -66,14 +66,14 @@ export var getFnParamNames = function (fn) {
     var match = fn.toString().match(/\(.*?\)/);
     return match ? match[0].replace(/[()]/gi, '').replace(/\s/gi, '').split(',') : [];
 };
-export var getValueForType = function (type, stringValue) {
+var getValueForType = function (type, stringValue) {
     switch (type) {
         case 'number':
             return Number(stringValue);
         case 'string':
             return stringValue;
         case 'boolean':
-            return true; // make this dynamic
+            return stringValue === 'true';
         case 'undefined':
             return undefined;
         case 'null':
@@ -84,6 +84,19 @@ export var getValueForType = function (type, stringValue) {
             return Number(stringValue);
     }
 };
+var getParamValuesForFunctionInvocation = function (params, fnName, formState) {
+    return params.map(function (param) {
+        var key = "".concat(fnName, "-").concat(param);
+        var paramValue = getValueForType(formState["".concat(key, "--types")], formState[key]);
+        if (isValidRev(paramValue)) {
+            return param;
+        }
+        if (typeof paramValue === 'string') {
+            return "'".concat(paramValue, "'");
+        }
+        return paramValue;
+    });
+};
 export var SmartObjectFunction = function (_a) {
     var smartObject = _a.smartObject, functionsExist = _a.functionsExist, options = _a.options, setFunctionResult = _a.setFunctionResult, setShow = _a.setShow, setModalTitle = _a.setModalTitle, funcName = _a.funcName;
     var paramList = getFnParamNames(Object.getPrototypeOf(smartObject)[funcName]).filter(function (val) { return val; });
@@ -91,7 +104,6 @@ export var SmartObjectFunction = function (_a) {
         ["".concat(funcName, "-").concat(key), ''],
         ["".concat(funcName, "-").concat(key, "--types"), ''],
     ]; }))), formState = _b[0], setFormState = _b[1];
-    console.log('testing: ', funcName, Object.keys(formState).length > 0 && Object.values(formState).every(function (value) { return value === ''; }), formState);
     var showLoader = UtilsContext.useUtilsComponents().showLoader;
     var computer = useContext(ComputerContext);
     var handleSmartObjectMethod = function (event, smartObj, fnName, params) { return __awaiter(void 0, void 0, void 0, function () {
@@ -105,6 +117,7 @@ export var SmartObjectFunction = function (_a) {
                 case 1:
                     _a.trys.push([1, 6, 7, 8]);
                     revMap_1 = {};
+                    // Create Rev Map to pass smart objects as params
                     params.forEach(function (param) {
                         var key = "".concat(fnName, "-").concat(param);
                         var paramValue = getValueForType(formState["".concat(key, "--types")], formState[key]);
@@ -113,17 +126,7 @@ export var SmartObjectFunction = function (_a) {
                         }
                     });
                     return [4 /*yield*/, computer.encode({
-                            exp: "smartObject.".concat(fnName, "(").concat(params.map(function (param) {
-                                var key = "".concat(fnName, "-").concat(param);
-                                var paramValue = getValueForType(formState["".concat(key, "--types")], formState[key]);
-                                if (isValidRev(paramValue)) {
-                                    return param;
-                                }
-                                if (typeof paramValue === 'string') {
-                                    return "'".concat(paramValue, "'");
-                                }
-                                return paramValue;
-                            }), ")"),
+                            exp: "smartObject.".concat(fnName, "(").concat(getParamValuesForFunctionInvocation(params, fnName, formState), ")"),
                             env: __assign({ smartObject: smartObj._rev }, revMap_1),
                             fund: true,
                             sign: true,
@@ -156,7 +159,7 @@ export var SmartObjectFunction = function (_a) {
             }
         });
     }); };
-    var updateFormValue = function (e, key) {
+    var updateForm = function (e, key) {
         e.preventDefault();
         var value = __assign({}, formState);
         value[key] = e.target.value;
@@ -173,7 +176,7 @@ export var SmartObjectFunction = function (_a) {
     }, [formState]);
     if (!functionsExist)
         return _jsx(_Fragment, {});
-    return (_jsx(_Fragment, { children: _jsxs("div", { className: "mt-6 mb-6", id: "function-".concat(funcName), children: [_jsx("h3", { className: "my-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(funcName) }), _jsxs("form", { children: [paramList.map(function (paramName, paramIndex) { return (_jsx("div", { className: "mb-4", children: _jsxs("div", { className: "flex items-center space-x-4", children: [_jsx("input", { type: "text", id: "".concat(funcName, "-").concat(paramName), value: formState["".concat(funcName, "-").concat(paramName)] || '', onChange: function (e) { return updateFormValue(e, "".concat(funcName, "-").concat(paramName)); }, className: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: paramName, required: true }), _jsx(TypeSelectionDropdown, { id: "".concat(funcName).concat(paramName), dropdownList: options, onSelectMethod: function (option) {
+    return (_jsx(_Fragment, { children: _jsxs("div", { className: "mt-6 mb-6", id: "function-".concat(funcName), children: [_jsx("h3", { className: "my-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(funcName) }), _jsxs("form", { children: [paramList.map(function (paramName, paramIndex) { return (_jsx("div", { className: "mb-4", children: _jsxs("div", { className: "flex items-center space-x-4", children: [_jsx("input", { type: "text", id: "".concat(funcName, "-").concat(paramName), value: formState["".concat(funcName, "-").concat(paramName)] || '', onChange: function (e) { return updateForm(e, "".concat(funcName, "-").concat(paramName)); }, className: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: paramName, required: true }), _jsx(TypeSelectionDropdown, { id: "".concat(funcName).concat(paramName), dropdownList: options, onSelectMethod: function (option) {
                                             return updateTypes(option, "".concat(funcName, "-").concat(paramName));
                                         } })] }) }, paramIndex)); }), _jsx("button", { id: "".concat(funcName, "-call-function-button"), disabled: isCallDisabled, className: "text-white font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 focus:ring-4 focus:outline-none\n              ".concat(isCallDisabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-700 hover:bg-blue-800 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800', "\n            "), onClick: function (evt) { return handleSmartObjectMethod(evt, smartObject, funcName, paramList); }, children: "Call Function" })] })] }) }));
 };

--- a/packages/components/built/SmartObjectFunction.js
+++ b/packages/components/built/SmartObjectFunction.js
@@ -54,17 +54,11 @@ import { ComputerContext } from './ComputerContext';
 export var getErrorMessage = function (error) {
     var _a, _b, _c, _d, _e, _f;
     if (((_b = (_a = error === null || error === void 0 ? void 0 : error.response) === null || _a === void 0 ? void 0 : _a.data) === null || _b === void 0 ? void 0 : _b.error) ===
-        'mandatory-script-verify-flag-failed (Operation not valid with the current stack size)') {
+        'mandatory-script-verify-flag-failed (Operation not valid with the current stack size)')
         return 'You are not authorized to make changes to this smart object';
-    }
-    if ((_d = (_c = error === null || error === void 0 ? void 0 : error.response) === null || _c === void 0 ? void 0 : _c.data) === null || _d === void 0 ? void 0 : _d.error) {
+    if ((_d = (_c = error === null || error === void 0 ? void 0 : error.response) === null || _c === void 0 ? void 0 : _c.data) === null || _d === void 0 ? void 0 : _d.error)
         return (_f = (_e = error === null || error === void 0 ? void 0 : error.response) === null || _e === void 0 ? void 0 : _e.data) === null || _f === void 0 ? void 0 : _f.error;
-    }
     return error.message ? error.message : 'Error occurred';
-};
-export var getFnParamNames = function (fn) {
-    var match = fn.toString().match(/\(.*?\)/);
-    return match ? match[0].replace(/[()]/gi, '').replace(/\s/gi, '').split(',') : [];
 };
 var getValueForType = function (type, stringValue) {
     switch (type) {
@@ -84,30 +78,32 @@ var getValueForType = function (type, stringValue) {
             return Number(stringValue);
     }
 };
-var getParamValuesForFunctionInvocation = function (params, fnName, formState) {
+export var getParameterNames = function (fn) {
+    var match = fn.toString().match(/\(.*?\)/);
+    return match ? match[0].replace(/[()]/gi, '').replace(/\s/gi, '').split(',') : [];
+};
+var getParameters = function (params, fnName, formState) {
     return params.map(function (param) {
         var key = "".concat(fnName, "-").concat(param);
         var paramValue = getValueForType(formState["".concat(key, "--types")], formState[key]);
-        if (isValidRev(paramValue)) {
+        if (isValidRev(paramValue))
             return param;
-        }
-        if (typeof paramValue === 'string') {
+        if (typeof paramValue === 'string')
             return "'".concat(paramValue, "'");
-        }
         return paramValue;
     });
 };
 export var SmartObjectFunction = function (_a) {
     var smartObject = _a.smartObject, functionsExist = _a.functionsExist, options = _a.options, setFunctionResult = _a.setFunctionResult, setShow = _a.setShow, setModalTitle = _a.setModalTitle, funcName = _a.funcName;
-    var paramList = getFnParamNames(Object.getPrototypeOf(smartObject)[funcName]).filter(function (val) { return val; });
-    var _b = useState(Object.fromEntries(paramList.flatMap(function (key) { return [
+    var parameterList = getParameterNames(Object.getPrototypeOf(smartObject)[funcName]).filter(function (val) { return val; });
+    var _b = useState(Object.fromEntries(parameterList.flatMap(function (key) { return [
         ["".concat(funcName, "-").concat(key), ''],
         ["".concat(funcName, "-").concat(key, "--types"), ''],
     ]; }))), formState = _b[0], setFormState = _b[1];
     var showLoader = UtilsContext.useUtilsComponents().showLoader;
     var computer = useContext(ComputerContext);
-    var handleSmartObjectMethod = function (event, smartObj, fnName, params) { return __awaiter(void 0, void 0, void 0, function () {
-        var revMap_1, tx, res, error_1;
+    var handleMethodCall = function (event, smartObj, fnName, params) { return __awaiter(void 0, void 0, void 0, function () {
+        var revMap_1, tx, rev, error_1;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
@@ -126,10 +122,8 @@ export var SmartObjectFunction = function (_a) {
                         }
                     });
                     return [4 /*yield*/, computer.encode({
-                            exp: "smartObject.".concat(fnName, "(").concat(getParamValuesForFunctionInvocation(params, fnName, formState), ")"),
+                            exp: "smartObject.".concat(fnName, "(").concat(getParameters(params, fnName, formState), ")"),
                             env: __assign({ smartObject: smartObj._rev }, revMap_1),
-                            fund: true,
-                            sign: true,
                         })];
                 case 2:
                     tx = (_a.sent()).tx;
@@ -141,8 +135,8 @@ export var SmartObjectFunction = function (_a) {
                     _a.sent();
                     return [4 /*yield*/, computer.query({ ids: [smartObject._id] })];
                 case 5:
-                    res = _a.sent();
-                    setFunctionResult({ _rev: res[0] });
+                    rev = (_a.sent())[0];
+                    setFunctionResult({ _rev: rev });
                     setModalTitle('Success');
                     setShow(true);
                     return [3 /*break*/, 8];
@@ -171,12 +165,12 @@ export var SmartObjectFunction = function (_a) {
         setFormState(value);
     };
     var capitalizeFirstLetter = function (s) { return s.charAt(0).toUpperCase() + s.slice(1); };
-    var isCallDisabled = useMemo(function () {
+    var isDisabled = useMemo(function () {
         return Object.keys(formState).length > 0 && Object.values(formState).some(function (value) { return value === ''; });
     }, [formState]);
     if (!functionsExist)
         return _jsx(_Fragment, {});
-    return (_jsx(_Fragment, { children: _jsxs("div", { className: "mt-6 mb-6", id: "function-".concat(funcName), children: [_jsx("h3", { className: "my-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(funcName) }), _jsxs("form", { children: [paramList.map(function (paramName, paramIndex) { return (_jsx("div", { className: "mb-4", children: _jsxs("div", { className: "flex items-center space-x-4", children: [_jsx("input", { type: "text", id: "".concat(funcName, "-").concat(paramName), value: formState["".concat(funcName, "-").concat(paramName)] || '', onChange: function (e) { return updateForm(e, "".concat(funcName, "-").concat(paramName)); }, className: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: paramName, required: true }), _jsx(TypeSelectionDropdown, { id: "".concat(funcName).concat(paramName), dropdownList: options, onSelectMethod: function (option) {
+    return (_jsx(_Fragment, { children: _jsxs("div", { className: "mt-6 mb-6", id: "function-".concat(funcName), children: [_jsx("h3", { className: "my-2 text-xl font-bold dark:text-white", children: capitalizeFirstLetter(funcName) }), _jsxs("form", { children: [parameterList.map(function (paramName, paramIndex) { return (_jsx("div", { className: "mb-4", children: _jsxs("div", { className: "flex items-center space-x-4", children: [_jsx("input", { type: "text", id: "".concat(funcName, "-").concat(paramName), value: formState["".concat(funcName, "-").concat(paramName)] || '', onChange: function (e) { return updateForm(e, "".concat(funcName, "-").concat(paramName)); }, className: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500", placeholder: paramName, required: true }), _jsx(TypeSelectionDropdown, { id: "".concat(funcName).concat(paramName), dropdownList: options, onSelectMethod: function (option) {
                                             return updateTypes(option, "".concat(funcName, "-").concat(paramName));
-                                        } })] }) }, paramIndex)); }), _jsx("button", { id: "".concat(funcName, "-call-function-button"), disabled: isCallDisabled, className: "text-white font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 focus:ring-4 focus:outline-none\n              ".concat(isCallDisabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-700 hover:bg-blue-800 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800', "\n            "), onClick: function (evt) { return handleSmartObjectMethod(evt, smartObject, funcName, paramList); }, children: "Call Function" })] })] }) }));
+                                        } })] }) }, paramIndex)); }), _jsx("button", { id: "".concat(funcName, "-call-function-button"), disabled: isDisabled, className: "text-white font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 focus:ring-4 focus:outline-none\n              ".concat(isDisabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-700 hover:bg-blue-800 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800', "\n            "), onClick: function (evt) { return handleMethodCall(evt, smartObject, funcName, parameterList); }, children: "Call Function" })] })] }) }));
 };

--- a/packages/components/built/SmartObjectFunctions.d.ts
+++ b/packages/components/built/SmartObjectFunctions.d.ts
@@ -1,0 +1,8 @@
+export declare const SmartObjectFunctions: ({ smartObject, functionsExist, options, setFunctionResult, setShow, setModalTitle, }: {
+    smartObject: any;
+    functionsExist: boolean;
+    options: string[];
+    setFunctionResult: React.Dispatch<any>;
+    setShow: any;
+    setModalTitle: React.Dispatch<React.SetStateAction<string>>;
+}) => import("react/jsx-runtime").JSX.Element;

--- a/packages/components/built/SmartObjectFunctions.js
+++ b/packages/components/built/SmartObjectFunctions.js
@@ -1,0 +1,14 @@
+import { Fragment as _Fragment, jsx as _jsx } from "react/jsx-runtime";
+import { SmartObjectFunction } from './SmartObjectFunction';
+export var SmartObjectFunctions = function (_a) {
+    var smartObject = _a.smartObject, functionsExist = _a.functionsExist, options = _a.options, setFunctionResult = _a.setFunctionResult, setShow = _a.setShow, setModalTitle = _a.setModalTitle;
+    if (!functionsExist)
+        return _jsx(_Fragment, {});
+    return (_jsx(_Fragment, { children: Object.getOwnPropertyNames(Object.getPrototypeOf(smartObject))
+            .filter(function (key) {
+            return key !== 'constructor' && typeof Object.getPrototypeOf(smartObject)[key] === 'function';
+        })
+            .map(function (key, fnIndex) {
+            return (_jsx("div", { children: _jsx(SmartObjectFunction, { funcName: key, smartObject: smartObject, functionsExist: functionsExist, options: options, setFunctionResult: setFunctionResult, setShow: setShow, setModalTitle: setModalTitle }) }, fnIndex));
+        }) }));
+};

--- a/packages/components/built/SmartObjectFunctions.js
+++ b/packages/components/built/SmartObjectFunctions.js
@@ -8,7 +8,5 @@ export var SmartObjectFunctions = function (_a) {
             .filter(function (key) {
             return key !== 'constructor' && typeof Object.getPrototypeOf(smartObject)[key] === 'function';
         })
-            .map(function (key, fnIndex) {
-            return (_jsx("div", { children: _jsx(SmartObjectFunction, { funcName: key, smartObject: smartObject, functionsExist: functionsExist, options: options, setFunctionResult: setFunctionResult, setShow: setShow, setModalTitle: setModalTitle }) }, fnIndex));
-        }) }));
+            .map(function (key, fnIndex) { return (_jsx("div", { children: _jsx(SmartObjectFunction, { funcName: key, smartObject: smartObject, functionsExist: functionsExist, options: options, setFunctionResult: setFunctionResult, setShow: setShow, setModalTitle: setModalTitle }) }, fnIndex)); }) }));
 };

--- a/packages/components/built/common/utils.d.ts
+++ b/packages/components/built/common/utils.d.ts
@@ -9,7 +9,7 @@ export declare const strip: (value: Json) => Json;
 export declare const toObject: (obj: any) => string;
 export declare const capitalizeFirstLetter: (string: string) => string;
 export declare function isValidRevString(outId: string): boolean;
-export declare function isValidRev(value: string | number | true | null | undefined): boolean;
+export declare function isValidRev(value: string | number | boolean | null | undefined): boolean;
 export declare const sleep: (ms: number) => Promise<void>;
 export declare function getEnv(name: string): any;
 export {};

--- a/packages/components/src/SmartObject.tsx
+++ b/packages/components/src/SmartObject.tsx
@@ -54,7 +54,7 @@ const SmartObjectValues = ({ smartObject }: any) => {
         .map(([key, value], i) => (
           <div key={i}>
             <h3 className="mt-2 text-xl font-bold dark:text-white">{capitalizeFirstLetter(key)}</h3>
-            <ObjectValueCard id={key} content={toObject(value || '')} />
+            <ObjectValueCard id={key} content={toObject(value)} />
           </div>
         ))}
     </>

--- a/packages/components/src/SmartObject.tsx
+++ b/packages/components/src/SmartObject.tsx
@@ -6,7 +6,7 @@ import { capitalizeFirstLetter, toObject } from './common/utils'
 import { Card } from './Card'
 import { Modal } from './Modal'
 import { FunctionResultModalContent } from './common/SmartCallExecutionResult'
-import { SmartObjectFunction } from './SmartObjectFunction'
+import { SmartObjectFunctions } from './SmartObjectFunctions'
 import { ComputerContext } from './ComputerContext'
 
 const keywords = ['_id', '_rev', '_owners', '_root', '_amount']
@@ -285,7 +285,7 @@ function Component({ title }: { title?: string }) {
 
         <SmartObjectValues smartObject={smartObject} />
 
-        <SmartObjectFunction
+        <SmartObjectFunctions
           smartObject={smartObject}
           functionsExist={functionsExist}
           options={options}

--- a/packages/components/src/SmartObjectFunction.tsx
+++ b/packages/components/src/SmartObjectFunction.tsx
@@ -8,7 +8,8 @@ export const getErrorMessage = (error: any): string => {
   if (
     error?.response?.data?.error ===
     'mandatory-script-verify-flag-failed (Operation not valid with the current stack size)'
-  ) return 'You are not authorized to make changes to this smart object'
+  )
+    return 'You are not authorized to make changes to this smart object'
   if (error?.response?.data?.error) return error?.response?.data?.error
   return error.message ? error.message : 'Error occurred'
 }
@@ -37,7 +38,8 @@ export const getParameterNames = (fn: string) => {
   return match ? match[0].replace(/[()]/gi, '').replace(/\s/gi, '').split(',') : []
 }
 
-const getParameters = (params: string[], fnName: string, formState: any) => params.map((param) => {
+const getParameters = (params: string[], fnName: string, formState: any) =>
+  params.map((param) => {
     const key = `${fnName}-${param}`
     const paramValue = getValueForType(formState[`${key}--types`], formState[key])
 
@@ -77,12 +79,7 @@ export const SmartObjectFunction = ({
   const { showLoader } = UtilsContext.useUtilsComponents()
   const computer = useContext(ComputerContext)
 
-  const handleMethodCall = async (
-    event: any,
-    smartObj: any,
-    fnName: string,
-    params: string[],
-  ) => {
+  const handleMethodCall = async (event: any, smartObj: any, fnName: string, params: string[]) => {
     event.preventDefault()
     showLoader(true)
     try {

--- a/packages/components/src/SmartObjectFunction.tsx
+++ b/packages/components/src/SmartObjectFunction.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { TypeSelectionDropdown } from './common/TypeSelectionDropdown'
 import { isValidRev, sleep } from './common/utils'
 import { UtilsContext } from './UtilsContext'
@@ -48,8 +48,33 @@ export const SmartObjectFunction = ({
   setFunctionResult,
   setShow,
   setModalTitle,
-}: any) => {
-  const [formState, setFormState] = useState<any>({})
+  funcName,
+}: {
+  smartObject: any
+  functionsExist: boolean
+  options: string[]
+  setFunctionResult: React.Dispatch<any>
+  setShow: any
+  setModalTitle: React.Dispatch<React.SetStateAction<string>>
+  funcName: string
+}) => {
+  const paramList = getFnParamNames(Object.getPrototypeOf(smartObject)[funcName]).filter(
+    (val) => val,
+  )
+  const [formState, setFormState] = useState<any>(
+    Object.fromEntries(
+      paramList.flatMap((key) => [
+        [`${funcName}-${key}`, ''],
+        [`${funcName}-${key}--types`, ''],
+      ]),
+    ),
+  )
+  console.log(
+    'testing: ',
+    funcName,
+    Object.keys(formState).length > 0 && Object.values(formState).every((value) => value === ''),
+    formState,
+  )
   const { showLoader } = UtilsContext.useUtilsComponents()
   const computer = useContext(ComputerContext)
 
@@ -120,55 +145,54 @@ export const SmartObjectFunction = ({
 
   const capitalizeFirstLetter = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
 
+  const isCallDisabled = useMemo(
+    () =>
+      Object.keys(formState).length > 0 && Object.values(formState).some((value) => value === ''),
+    [formState],
+  )
+
   if (!functionsExist) return <></>
   return (
     <>
-      {Object.getOwnPropertyNames(Object.getPrototypeOf(smartObject))
-        .filter(
-          (key) =>
-            key !== 'constructor' && typeof Object.getPrototypeOf(smartObject)[key] === 'function',
-        )
-        .map((key, fnIndex) => {
-          const paramList = getFnParamNames(Object.getPrototypeOf(smartObject)[key])
-          return (
-            <div className="mt-6 mb-6" key={fnIndex} id={`function-${key}`}>
-              <h3 className="my-2 text-xl font-bold dark:text-white">
-                {capitalizeFirstLetter(key)}
-              </h3>
-              <form id={`fn-index-${fnIndex}`}>
-                {paramList.map((paramName, paramIndex) => (
-                  <div key={paramIndex} className="mb-4">
-                    <div className="flex items-center space-x-4">
-                      <input
-                        type="text"
-                        id={`${key}-${paramName}`}
-                        value={formState[`${key}-${paramName}`] || ''}
-                        onChange={(e) => updateFormValue(e, `${key}-${paramName}`)}
-                        className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-                        placeholder={paramName}
-                        required
-                      />
-                      <TypeSelectionDropdown
-                        id={`${key}${paramName}`}
-                        dropdownList={options}
-                        onSelectMethod={(option: string) =>
-                          updateTypes(option, `${key}-${paramName}`)
-                        }
-                      />
-                    </div>
-                  </div>
-                ))}
-                <button
-                  id={`${key}-call-function-button`}
-                  className="text-gray-900 bg-white border border-gray-300 focus:outline-none hover:bg-gray-100 focus:ring-4 focus:ring-gray-100 font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 dark:bg-gray-800 dark:text-white dark:border-gray-600 dark:hover:bg-gray-700 dark:hover:border-gray-600 dark:focus:ring-gray-700"
-                  onClick={(evt) => handleSmartObjectMethod(evt, smartObject, key, paramList)}
-                >
-                  Call Function
-                </button>
-              </form>
+      <div className="mt-6 mb-6" id={`function-${funcName}`}>
+        <h3 className="my-2 text-xl font-bold dark:text-white">
+          {capitalizeFirstLetter(funcName)}
+        </h3>
+        <form>
+          {paramList.map((paramName, paramIndex) => (
+            <div key={paramIndex} className="mb-4">
+              <div className="flex items-center space-x-4">
+                <input
+                  type="text"
+                  id={`${funcName}-${paramName}`}
+                  value={formState[`${funcName}-${paramName}`] || ''}
+                  onChange={(e) => updateFormValue(e, `${funcName}-${paramName}`)}
+                  className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+                  placeholder={paramName}
+                  required
+                />
+                <TypeSelectionDropdown
+                  id={`${funcName}${paramName}`}
+                  dropdownList={options}
+                  onSelectMethod={(option: string) =>
+                    updateTypes(option, `${funcName}-${paramName}`)
+                  }
+                />
+              </div>
             </div>
-          )
-        })}
+          ))}
+          <button
+            id={`${funcName}-call-function-button`}
+            disabled={isCallDisabled}
+            className={`text-white font-medium rounded-lg text-sm px-5 py-2.5 me-2 mb-2 focus:ring-4 focus:outline-none
+              ${isCallDisabled ? 'bg-gray-400 cursor-not-allowed' : 'bg-blue-700 hover:bg-blue-800 focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800'}
+            `}
+            onClick={(evt) => handleSmartObjectMethod(evt, smartObject, funcName, paramList)}
+          >
+            Call Function
+          </button>
+        </form>
+      </div>
     </>
   )
 }

--- a/packages/components/src/SmartObjectFunctions.tsx
+++ b/packages/components/src/SmartObjectFunctions.tsx
@@ -1,0 +1,41 @@
+import { SmartObjectFunction } from './SmartObjectFunction'
+
+export const SmartObjectFunctions = ({
+  smartObject,
+  functionsExist,
+  options,
+  setFunctionResult,
+  setShow,
+  setModalTitle,
+}: {
+  smartObject: any
+  functionsExist: boolean
+  options: string[]
+  setFunctionResult: React.Dispatch<any>
+  setShow: any
+  setModalTitle: React.Dispatch<React.SetStateAction<string>>
+}) => {
+  if (!functionsExist) return <></>
+  return (
+    <>
+      {Object.getOwnPropertyNames(Object.getPrototypeOf(smartObject))
+        .filter(
+          (key) =>
+            key !== 'constructor' && typeof Object.getPrototypeOf(smartObject)[key] === 'function',
+        )
+        .map((key, fnIndex) => (
+            <div key={fnIndex}>
+              <SmartObjectFunction
+                funcName={key}
+                smartObject={smartObject}
+                functionsExist={functionsExist}
+                options={options}
+                setFunctionResult={setFunctionResult}
+                setShow={setShow}
+                setModalTitle={setModalTitle}
+              ></SmartObjectFunction>
+            </div>
+          ))}
+    </>
+  )
+}

--- a/packages/components/src/common/utils.ts
+++ b/packages/components/src/common/utils.ts
@@ -60,7 +60,7 @@ export function isValidRevString(outId: string): boolean {
   return /^[0-9A-Fa-f]{64}:\d+$/.test(outId)
 }
 
-export function isValidRev(value: string | number | true | null | undefined): boolean {
+export function isValidRev(value: string | number | boolean | null | undefined): boolean {
   return typeof value === 'string' && isValidRevString(value)
 }
 

--- a/packages/explorer/src/components/playground/CreateNew.tsx
+++ b/packages/explorer/src/components/playground/CreateNew.tsx
@@ -115,6 +115,7 @@ const CreateNew = (props: {
         sleep(500)
         // eslint-disable-next-line
         const { res } = (await computer.sync(txId)) as any
+        console.log(txId, res)
         setFunctionResult({ _rev: res._rev, type: 'objects' })
         setModalTitle('Success!')
         setShow(true)

--- a/packages/explorer/src/components/playground/CreateNew.tsx
+++ b/packages/explorer/src/components/playground/CreateNew.tsx
@@ -115,7 +115,6 @@ const CreateNew = (props: {
         sleep(500)
         // eslint-disable-next-line
         const { res } = (await computer.sync(txId)) as any
-        console.log(txId, res)
         setFunctionResult({ _rev: res._rev, type: 'objects' })
         setModalTitle('Success!')
         setShow(true)


### PR DESCRIPTION
* Disables the call button on the explorer if the users has not selected a type for every argument
* Refactores the smart object page of the explorer to make it easier to read
* Fix formatting