### PR TITLE
Automated DockerHub publishing on tag creation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           # Extract the version from package.json
           VERSION=$(node -p "require('./package.json').version")
           echo "Extracted version: $VERSION"
-          echo "::set-output name=version::$VERSION"
+          echo "::set-output name=version::[\"$VERSION\"]"
   build:
     needs: extract-version
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,13 +45,14 @@ jobs:
           PUSH=false
           DOCKER_REPO=bcdb/bcn
           TAGS=("$DOCKER_REPO:${BCN_VERSION} $DOCKER_REPO:latest")
-          echo "Building BCN_VERSION $BCN_VERSION/ for PLATFORMS ${PLATFORMS}/"
+          echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
           echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=docker_platforms::${PLATFORMS}
           echo ::set-output name=push::${PUSH}
           echo ::set-output name=tags::${TAGS[@]}
 
       - name: Build Docker image
+        working-directory: ./
         run: |
           TAGS=(${{ steps.prepare.outputs.tags }})
           docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,10 +75,15 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y docker-compose
 
+      - name: Install dependencies (npm install)
+        working-directory: packages/node
+        continue-on-error: true
+        run: |
+          npm install || echo "npm install failed, but continuing..."
+
       - name: Start services in regtest mode
         working-directory: packages/node
         run: |
-          npm install ;
           npm run up &
           echo "Waiting for services to start..."
           sleep 20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Login into Docker Hub
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: |
+          echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
+
       - name: Prepare Docker build
         id: prepare
         run: |
@@ -64,6 +71,11 @@ jobs:
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             --tag ${{ steps.prepare.outputs.temp_tag }} \
             -f Dockerfile .
+
+       - name: Clear DockerHub credentials
+        run: |
+          rm -f ${HOME}/.docker/config.json
+
   integration-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: build-and-test
 
 on:
   push:
-    branches: [feat/registry]
+    tags:
+      - "*"
 
 jobs:
   extract-version:
@@ -19,8 +20,70 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "Extracted version: $VERSION"
           echo "version=[\"$VERSION\"]" >> $GITHUB_OUTPUT
+  build:
+    needs: extract-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.extract-version.outputs.version) }}
+        folder:
+          - "packages/node"
+      fail-fast: false
+    outputs:
+      temp_tag: ${{ steps.prepare.outputs.temp_tag }}
+      final_tags: ${{ steps.prepare.outputs.final_tags }}
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login into Docker Hub
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: |
+          echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
+
+      - name: Prepare Docker build
+        id: prepare
+        run: |
+          BCN_VERSION=${{matrix.version}}
+          PLATFORMS="linux/amd64,linux/arm64/v8"
+          PUSH=true
+          DOCKER_REPO=bcdb/bcn
+          TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
+          FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
+          echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
+          echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=docker_platforms::${PLATFORMS}
+          echo ::set-output name=push::${PUSH}
+          echo ::set-output name=temp_tag::${TEMP_TAG}
+          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
+          echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
+          echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
+
+      - name: Build and push temporary image
+        working-directory: ./
+        run: |
+          docker buildx create --use
+          docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
+            --output "type=image,push=${{steps.prepare.outputs.push}}" \
+            --progress=plain \
+            --tag ${{ steps.prepare.outputs.temp_tag }} \
+            -f Dockerfile .
+
+      - name: Debug temp_tag
+        run: |
+          echo "Temporary tag: ${{ steps.prepare.outputs.temp_tag }}"
+
+      - name: Clear DockerHub credentials
+        run: |
+          rm -f ${HOME}/.docker/config.json
   integration-tests:
-    needs: [extract-version]
+    needs: [build, extract-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,38 +42,42 @@ jobs:
 
           BCN_VERSION=${{matrix.version}}
           PLATFORMS="linux/amd64"
-          PUSH=false
+          PUSH=true
           DOCKER_REPO=bcdb/bcn
-          TAGS=("$DOCKER_REPO:${BCN_VERSION} $DOCKER_REPO:latest")
+          TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
+          FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
           echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
           echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=docker_platforms::${PLATFORMS}
           echo ::set-output name=push::${PUSH}
-          echo ::set-output name=tags::${TAGS[@]}
+          echo ::set-output name=temp_tag::${TEMP_TAG}
+          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
 
-      - name: List files in root directory
-        run: ls -la
-
-      - name: Build Docker image
+      - name: Build and push temporary image
         working-directory: ./
         run: |
-          TAGS=(${{ steps.prepare.outputs.tags }})
+          docker buildx create --use
           docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
             --output "type=image,push=${{steps.prepare.outputs.push}}" \
             --progress=plain \
             --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
-            $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
+            --tag ${{ steps.prepare.outputs.temp_tag }} \
             -f Dockerfile .
   integration-tests:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
     defaults:
       run:
         working-directory: packages/node
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Pull temporary image
+        run: |
+          docker pull ${{ needs.build.outputs.temp_tag }}
 
       - name: Copy configuration files
         run: |
@@ -89,9 +93,9 @@ jobs:
 
       - name: Start services in regtest mode
         run: |
-          npm run up
+          npm run up &
           echo "Waiting for services to start..."
-          sleep 120
+          sleep 20
 
       - name: Run integration tests
         run: |
@@ -104,10 +108,10 @@ jobs:
       - name: Stop services
         run: |
           npm run down
-  push-to-registry:
+  re-tag-and-push:
     needs: [build, integration-tests]
     runs-on: ubuntu-latest
-    if: always() && needs.integration-tests.result == 'success' # Push only if tests pass
+    if: always() && needs.integration-tests.result == 'success'
     steps:
       - name: Login into Docker Hub
         env:
@@ -116,7 +120,20 @@ jobs:
         run: |
           echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
 
-      - name: Push Docker image
+      - name: Pull temporary image
         run: |
-          TAGS=(${{ needs.build.outputs.image_tag }})
-          docker push ${{ needs.build.outputs.image_tag }}
+          docker pull ${{ needs.build.outputs.temp_tag }}
+
+      - name: Re-tag image
+        run: |
+          TEMP_TAG="${{ needs.build.outputs.temp_tag }}"
+          FINAL_TAGS=(${{ needs.build.outputs.final_tags }})
+          for TAG in "${FINAL_TAGS[@]}"; do
+            docker tag "$TEMP_TAG" "$TAG"
+          done
+      - name: Push final tags
+        run: |
+          FINAL_TAGS=(${{ needs.build.outputs.final_tags }})
+          for TAG in "${FINAL_TAGS[@]}"; do
+            docker push "$TAG"
+          done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: build-and-test
+
 on:
   push:
     branches: [feat/registry]
@@ -18,7 +19,8 @@ jobs:
           # Extract the version from package.json
           VERSION=$(node -p "require('./package.json').version")
           echo "Extracted version: $VERSION"
-          echo "::set-output name=version::[\"$VERSION\"]"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   build:
     needs: extract-version
     runs-on: ubuntu-latest
@@ -31,6 +33,7 @@ jobs:
     outputs:
       temp_tag: ${{ steps.prepare.outputs.temp_tag }}
       final_tags: ${{ steps.prepare.outputs.final_tags }}
+
     steps:
       - name: Set up Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v1
@@ -48,8 +51,6 @@ jobs:
       - name: Prepare Docker build
         id: prepare
         run: |
-          function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
-
           BCN_VERSION=${{matrix.version}}
           PLATFORMS="linux/amd64"
           PUSH=true
@@ -57,25 +58,21 @@ jobs:
           TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
           FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
           echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
-          echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=docker_platforms::${PLATFORMS}
-          echo ::set-output name=push::${PUSH}
-          echo ::set-output name=temp_tag::${TEMP_TAG}
-          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
           echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
           echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
 
       - name: Build and push temporary image
-        working-directory: ./
         run: |
           docker buildx create --use
           docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
             --output "type=image,push=${{steps.prepare.outputs.push}}" \
             --progress=plain \
-            --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
-            --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             --tag ${{ steps.prepare.outputs.temp_tag }} \
             -f Dockerfile .
+
+      - name: Debug temp_tag
+        run: |
+          echo "Temporary tag: ${{ steps.prepare.outputs.temp_tag }}"
 
       - name: Clear DockerHub credentials
         run: |
@@ -88,9 +85,7 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-    defaults:
-      run:
-        working-directory: packages/node
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -127,6 +122,7 @@ jobs:
           sleep 20
 
       - name: Run integration tests
+        working-directory: packages/node
         run: |
           npm run test
 
@@ -135,12 +131,15 @@ jobs:
           rm -f ${HOME}/.docker/config.json
 
       - name: Stop services
+        working-directory: packages/node
         run: |
           npm run down
+
   re-tag-and-push:
     needs: [build, integration-tests]
     runs-on: ubuntu-latest
     if: always() && needs.integration-tests.result == 'success'
+
     steps:
       - name: Login into Docker Hub
         env:
@@ -160,9 +159,14 @@ jobs:
           for TAG in "${FINAL_TAGS[@]}"; do
             docker tag "$TEMP_TAG" "$TAG"
           done
+
       - name: Push final tags
         run: |
           FINAL_TAGS=(${{ needs.build.outputs.final_tags }})
           for TAG in "${FINAL_TAGS[@]}"; do
             docker push "$TAG"
           done
+
+      - name: Clear DockerHub credentials
+        run: |
+          rm -f ${HOME}/.docker/config.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,9 @@ jobs:
       - name: Extract version from package.json
         id: extract
         run: |
-          # Extract the version from package.json
           VERSION=$(node -p "require('./package.json').version")
           echo "Extracted version: $VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version=[\"$VERSION\"]" >> $GITHUB_OUTPUT
 
   build:
     needs: extract-version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,9 +92,9 @@ jobs:
           docker pull bcdb/bcn:${{ needs.build.outputs.temp_tag }}
 
       - name: Re-tag image for docker-compose
-      run: |
-        docker tag bcdb/bcn:${{ needs.build.outputs.temp_tag }} bitcoin-computer-node
-        echo "Re-tagged image as bitcoin-computer-node"
+        run: |
+          docker tag bcdb/bcn:${{ needs.build.outputs.temp_tag }} bitcoin-computer-node
+          echo "Re-tagged image as bitcoin-computer-node"
 
       - name: Copy configuration files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: build-and-test
-on: 
+on:
   push:
     branches: [feat/registry]
 
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ ${{ needs.extract-version.outputs.version }} ]
+        version: ${{ fromJson(needs.extract-version.outputs.version) }}
         folder:
-          - 'packages/node'
+          - "packages/node"
       fail-fast: false
     steps:
       - name: Set up Docker Buildx
@@ -60,7 +60,7 @@ jobs:
             --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            ${{ matrix.folder }}/ 
+            ${{ matrix.folder }}/
   integration-tests:
     needs: build
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
         run: |
           npm run up
           echo "Waiting for services to start..."
-          sleep 120 
+          sleep 120
 
       - name: Run integration tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Start services in regtest mode
         working-directory: packages/node
         run: |
-          npm install &&
+          npm install ;
           npm run up &
           echo "Waiting for services to start..."
           sleep 20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,12 @@ jobs:
     steps:
       - name: Pull temporary image
         run: |
-          docker pull ${{ needs.build.outputs.temp_tag }}
+          docker pull bcdb/bcn:${{ needs.build.outputs.temp_tag }}
+
+      - name: Re-tag image for docker-compose
+      run: |
+        docker tag bcdb/bcn:${{ needs.build.outputs.temp_tag }} bitcoin-computer-node
+        echo "Re-tagged image as bitcoin-computer-node"
 
       - name: Copy configuration files
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Start services in regtest mode
         working-directory: packages/node
         run: |
-          npm run install &&
+          npm install &&
           npm run up &
           echo "Waiting for services to start..."
           sleep 20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,68 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "Extracted version: $VERSION"
           echo "version=[\"$VERSION\"]" >> $GITHUB_OUTPUT
+  build:
+    needs: extract-version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ${{ fromJson(needs.extract-version.outputs.version) }}
+        folder:
+          - "packages/node"
+      fail-fast: false
+    outputs:
+      temp_tag: ${{ steps.prepare.outputs.temp_tag }}
+      final_tags: ${{ steps.prepare.outputs.final_tags }}
 
+    steps:
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login into Docker Hub
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: |
+          echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
+
+      - name: Prepare Docker build
+        id: prepare
+        run: |
+          BCN_VERSION=${{matrix.version}}
+          PLATFORMS="linux/amd64"
+          PUSH=true
+          DOCKER_REPO=bcdb/bcn
+          TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
+          FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
+          echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
+          echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=docker_platforms::${PLATFORMS}
+          echo ::set-output name=push::${PUSH}
+          echo ::set-output name=temp_tag::${TEMP_TAG}
+          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
+          echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
+          echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
+
+      - name: Build and push temporary image
+        working-directory: ./
+        run: |
+          docker buildx create --use
+          docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
+            --output "type=image,push=${{steps.prepare.outputs.push}}" \
+            --progress=plain \
+            --tag ${{ steps.prepare.outputs.temp_tag }} \
+            -f Dockerfile .
+
+      - name: Debug temp_tag
+        run: |
+          echo "Temporary tag: ${{ steps.prepare.outputs.temp_tag }}"
+
+      - name: Clear DockerHub credentials
+        run: |
+          rm -f ${HOME}/.docker/config.json
   integration-tests:
     needs: [extract-version]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,30 @@
-name: build
+name: build-and-test
 on: 
   push:
-    branches: [ bcn-multiplatform ]
+    branches: [feat/registry]
 
 jobs:
+  extract-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Extract version from package.json
+        id: extract
+        run: |
+          # Extract the version from package.json
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Extracted version: $VERSION"
+          echo "::set-output name=version::$VERSION"
   build:
+    needs: extract-version
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version:
-          - '0.10.0-alpha.4'
+        version: [ ${{ needs.extract-version.outputs.version }} ]
         folder:
           - 'packages/node'
       fail-fast: false
@@ -20,27 +35,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Login into Docker Hub
-        env:
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-        run: |
-          echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
-
       - name: Prepare Docker build
         id: prepare
         run: |
           function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
           BCN_VERSION=${{matrix.version}}
-          PLATFORMS="linux/amd64,linux/arm64/v8,linux/arm/v7"
-          PUSH=true
+          PLATFORMS="linux/amd64"
+          PUSH=false
           DOCKER_REPO=bcdb/bcn
-
           TAGS=("$DOCKER_REPO:${BCN_VERSION} $DOCKER_REPO:latest")
-
           echo "Building BCN_VERSION $BCN_VERSION/ for PLATFORMS ${PLATFORMS}/"
-
           echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           echo ::set-output name=docker_platforms::${PLATFORMS}
           echo ::set-output name=push::${PUSH}
@@ -49,28 +54,61 @@ jobs:
       - name: Build Docker image
         run: |
           TAGS=(${{ steps.prepare.outputs.tags }})
-
-          echo "Build date: ${{ steps.prepare.outputs.build_date }}"
-          echo "Docker platform: ${{ steps.prepare.outputs.docker_platforms }}"
-          echo "Push: ${{ steps.prepare.outputs.push }}"
-          echo "Tags: ${{ steps.prepare.outputs.tags }}"
-
-          echo docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
-            --output "type=image,push=${{steps.prepare.outputs.push}}" \
-            --progress=plain \
-            --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
-            --build-arg "VCS_REF=${GITHUB_SHA::8}" \
-            $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            ${{ matrix.folder }}/
-
           docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
             --output "type=image,push=${{steps.prepare.outputs.push}}" \
             --progress=plain \
             --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            ${{ matrix.folder }}/
+            ${{ matrix.folder }}/ 
+  integration-tests:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
+      - name: Copy .env.example to .env
+        run: |
+          # Copy the .env.example file to .env
+          cp packages/node/chain-setup/LTC/regtest/.env.example packages/node/.env
+          echo "Copied .env.example to .env"
+          cp packages/node/chain-setup/LTC/regtest/litecoin.conf.example packages/node/litecoin.conf
+          echo "Copied litecoin.conf.example to litecoin.conf"
+
+      - name: Set up Docker Compose
+        run: |
+          sudo apt-get update && sudo apt-get install -y docker-compose
+
+      - name: Start services in regtest mode
+        run: |
+          npm run up
+          echo "Waiting for services to start..."
+          sleep 120 
+
+      - name: Run integration tests
+        run: |
+          # Replace this with your actual test command
+          ./run-integration-tests.sh
       - name: Clear DockerHub credentials
         run: |
           rm -f ${HOME}/.docker/config.json
+      - name: Stop services
+        run: |
+          docker-compose -f docker-compose.regtest.yml down
+  push-to-registry:
+    needs: [build, integration-tests]
+    runs-on: ubuntu-latest
+    if: always() && needs.integration-tests.result == 'success' # Push only if tests pass
+    steps:
+      - name: Login into Docker Hub
+        env:
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+        run: |
+          echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
+
+      - name: Push Docker image
+        run: |
+          TAGS=(${{ needs.build.outputs.image_tag }})
+          docker push ${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,13 +87,20 @@ jobs:
       run:
         working-directory: packages/node
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Debug temp_tag
+        run: |
+          echo "Temporary tag from build job: ${{ needs.build.outputs.temp_tag }}"
+
       - name: Pull temporary image
         run: |
-          docker pull bcdb/bcn:${{ needs.build.outputs.temp_tag }}
+          docker pull ${{ needs.build.outputs.temp_tag }}
 
       - name: Re-tag image for docker-compose
         run: |
-          docker tag bcdb/bcn:${{ needs.build.outputs.temp_tag }} bitcoin-computer-node
+          docker tag ${{ needs.build.outputs.temp_tag }} bitcoin-computer-node
           echo "Re-tagged image as bitcoin-computer-node"
 
       - name: Copy configuration files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         version: ${{ fromJson(needs.extract-version.outputs.version) }}
         folder:
-          - "."
+          - "./"
       fail-fast: false
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,8 @@ jobs:
           echo ::set-output name=push::${PUSH}
           echo ::set-output name=temp_tag::${TEMP_TAG}
           echo ::set-output name=final_tags::${FINAL_TAGS[@]}
+          echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
+          echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
 
       - name: Build and push temporary image
         working-directory: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         version: ${{ fromJson(needs.extract-version.outputs.version) }}
         folder:
-          - "packages/node"
+          - "."
       fail-fast: false
     steps:
       - name: Set up Docker Buildx
@@ -61,7 +61,8 @@ jobs:
             --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            ${{ matrix.folder }}/
+            -f Dockerfile \ 
+            .
   integration-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,16 @@ jobs:
           TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
           FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
           echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
+          echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=docker_platforms::${PLATFORMS}
+          echo ::set-output name=push::${PUSH}
+          echo ::set-output name=temp_tag::${TEMP_TAG}
+          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
           echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
           echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
 
       - name: Build and push temporary image
+        working-directory: ./
         run: |
           docker buildx create --use
           docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,9 @@ jobs:
           sudo apt-get update && sudo apt-get install -y docker-compose
 
       - name: Start services in regtest mode
+        working-directory: packages/node
         run: |
+          npm run install &&
           npm run up &
           echo "Waiting for services to start..."
           sleep 20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,28 +84,45 @@ jobs:
           rm -f ${HOME}/.docker/config.json
 
   integration-tests:
-    needs: build
+    needs: [build, extract-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        version: ${{ fromJson(needs.extract-version.outputs.version) }}
         platform:
           - linux/amd64
-
+    outputs:
+      temp_tag: ${{ steps.prepare.outputs.temp_tag }}
+      final_tags: ${{ steps.prepare.outputs.final_tags }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Prepare Docker build
+        id: prepare
+        run: |
+          BCN_VERSION=${{matrix.version}}
+          PLATFORMS="linux/amd64"
+          PUSH=true
+          DOCKER_REPO=bcdb/bcn
+          TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
+          FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
+          echo ::set-output name=temp_tag::${TEMP_TAG}
+          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
+          echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
+          echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
+
       - name: Debug temp_tag
         run: |
-          echo "Temporary tag from build job: ${{ needs.build.outputs.temp_tag }}"
+          echo "Temporary tag from build job: ${{ steps.prepare.outputs.temp_tag }}"
 
       - name: Pull temporary image
         run: |
-          docker pull ${{ needs.build.outputs.temp_tag }}
+          docker pull ${{ steps.prepare.outputs.temp_tag }}
 
       - name: Re-tag image for docker-compose
         run: |
-          docker tag ${{ needs.build.outputs.temp_tag }} bitcoin-computer-node
+          docker tag ${{ steps.prepare.outputs.temp_tag }} bitcoin-computer-node
           echo "Re-tagged image as bitcoin-computer-node"
 
       - name: Copy configuration files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,7 @@ jobs:
             --build-arg "BUILD_DATE=${{ steps.prepare.outputs.build_date }}" \
             --build-arg "VCS_REF=${GITHUB_SHA::8}" \
             $(printf "%s" "${TAGS[@]/#/ --tag }" ) \
-            -f Dockerfile \ 
-            .
+            -f Dockerfile .
   integration-tests:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,16 +68,19 @@ jobs:
   integration-tests:
     needs: build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/node
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Copy .env.example to .env
+      - name: Copy configuration files
         run: |
-          # Copy the .env.example file to .env
-          cp packages/node/chain-setup/LTC/regtest/.env.example packages/node/.env
+          cp chain-setup/LTC/regtest/.env.example .env
           echo "Copied .env.example to .env"
-          cp packages/node/chain-setup/LTC/regtest/litecoin.conf.example packages/node/litecoin.conf
+
+          cp chain-setup/LTC/regtest/litecoin.conf.example litecoin.conf
           echo "Copied litecoin.conf.example to litecoin.conf"
 
       - name: Set up Docker Compose
@@ -92,14 +95,15 @@ jobs:
 
       - name: Run integration tests
         run: |
-          # Replace this with your actual test command
-          ./run-integration-tests.sh
+          npm run test
+
       - name: Clear DockerHub credentials
         run: |
           rm -f ${HOME}/.docker/config.json
+
       - name: Stop services
         run: |
-          docker-compose -f docker-compose.regtest.yml down
+          npm run down
   push-to-registry:
     needs: [build, integration-tests]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,71 +20,8 @@ jobs:
           echo "Extracted version: $VERSION"
           echo "version=[\"$VERSION\"]" >> $GITHUB_OUTPUT
 
-  build:
-    needs: extract-version
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ${{ fromJson(needs.extract-version.outputs.version) }}
-        folder:
-          - "packages/node"
-      fail-fast: false
-    outputs:
-      temp_tag: ${{ steps.prepare.outputs.temp_tag }}
-      final_tags: ${{ steps.prepare.outputs.final_tags }}
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Login into Docker Hub
-        env:
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-        run: |
-          echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
-
-      - name: Prepare Docker build
-        id: prepare
-        run: |
-          BCN_VERSION=${{matrix.version}}
-          PLATFORMS="linux/amd64"
-          PUSH=true
-          DOCKER_REPO=bcdb/bcn
-          TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
-          FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
-          echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
-          echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=docker_platforms::${PLATFORMS}
-          echo ::set-output name=push::${PUSH}
-          echo ::set-output name=temp_tag::${TEMP_TAG}
-          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
-          echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
-          echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
-
-      - name: Build and push temporary image
-        working-directory: ./
-        run: |
-          docker buildx create --use
-          docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
-            --output "type=image,push=${{steps.prepare.outputs.push}}" \
-            --progress=plain \
-            --tag ${{ steps.prepare.outputs.temp_tag }} \
-            -f Dockerfile .
-
-      - name: Debug temp_tag
-        run: |
-          echo "Temporary tag: ${{ steps.prepare.outputs.temp_tag }}"
-
-      - name: Clear DockerHub credentials
-        run: |
-          rm -f ${HOME}/.docker/config.json
-
   integration-tests:
-    needs: [build, extract-version]
+    needs: [extract-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -126,6 +63,7 @@ jobs:
           echo "Re-tagged image as bitcoin-computer-node"
 
       - name: Copy configuration files
+        working-directory: packages/node
         run: |
           cp chain-setup/LTC/regtest/.env.example .env
           echo "Copied .env.example to .env"
@@ -158,7 +96,7 @@ jobs:
           npm run down
 
   re-tag-and-push:
-    needs: [build, integration-tests]
+    needs: [integration-tests]
     runs-on: ubuntu-latest
     if: always() && needs.integration-tests.result == 'success'
 
@@ -172,19 +110,19 @@ jobs:
 
       - name: Pull temporary image
         run: |
-          docker pull ${{ needs.build.outputs.temp_tag }}
+          docker pull ${{ needs.integration-tests.outputs.temp_tag }}
 
       - name: Re-tag image
         run: |
-          TEMP_TAG="${{ needs.build.outputs.temp_tag }}"
-          FINAL_TAGS=(${{ needs.build.outputs.final_tags }})
+          TEMP_TAG="${{ needs.integration-tests.outputs.temp_tag }}"
+          FINAL_TAGS=(${{ needs.integration-tests.outputs.final_tags }})
           for TAG in "${FINAL_TAGS[@]}"; do
             docker tag "$TEMP_TAG" "$TAG"
           done
 
       - name: Push final tags
         run: |
-          FINAL_TAGS=(${{ needs.build.outputs.final_tags }})
+          FINAL_TAGS=(${{ needs.integration-tests.outputs.final_tags }})
           for TAG in "${FINAL_TAGS[@]}"; do
             docker push "$TAG"
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         version: ${{ fromJson(needs.extract-version.outputs.version) }}
         folder:
-          - "./"
+          - "packages/node"
       fail-fast: false
     steps:
       - name: Set up Docker Buildx
@@ -50,6 +50,9 @@ jobs:
           echo ::set-output name=docker_platforms::${PLATFORMS}
           echo ::set-output name=push::${PUSH}
           echo ::set-output name=tags::${TAGS[@]}
+
+      - name: List files in root directory
+        run: ls -la
 
       - name: Build Docker image
         working-directory: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         id: prepare
         run: |
           BCN_VERSION=${{matrix.version}}
-          PLATFORMS="linux/amd64"
+          PLATFORMS="linux/amd64,linux/arm64/v8"
           PUSH=true
           DOCKER_REPO=bcdb/bcn
           TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
@@ -89,6 +89,7 @@ jobs:
         version: ${{ fromJson(needs.extract-version.outputs.version) }}
         platform:
           - linux/amd64
+          - linux/arm64
     outputs:
       temp_tag: ${{ steps.prepare.outputs.temp_tag }}
       final_tags: ${{ steps.prepare.outputs.final_tags }}
@@ -100,8 +101,6 @@ jobs:
         id: prepare
         run: |
           BCN_VERSION=${{matrix.version}}
-          PLATFORMS="linux/amd64"
-          PUSH=true
           DOCKER_REPO=bcdb/bcn
           TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
           FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,70 +19,8 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           echo "Extracted version: $VERSION"
           echo "version=[\"$VERSION\"]" >> $GITHUB_OUTPUT
-  build:
-    needs: extract-version
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ${{ fromJson(needs.extract-version.outputs.version) }}
-        folder:
-          - "packages/node"
-      fail-fast: false
-    outputs:
-      temp_tag: ${{ steps.prepare.outputs.temp_tag }}
-      final_tags: ${{ steps.prepare.outputs.final_tags }}
-
-    steps:
-      - name: Set up Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Login into Docker Hub
-        env:
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
-        run: |
-          echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
-
-      - name: Prepare Docker build
-        id: prepare
-        run: |
-          BCN_VERSION=${{matrix.version}}
-          PLATFORMS="linux/amd64,linux/arm64/v8"
-          PUSH=true
-          DOCKER_REPO=bcdb/bcn
-          TEMP_TAG="${DOCKER_REPO}:${BCN_VERSION}-pre-release"
-          FINAL_TAGS=("${DOCKER_REPO}:${BCN_VERSION} ${DOCKER_REPO}:latest")
-          echo "Building BCN_VERSION $BCN_VERSION for PLATFORMS ${PLATFORMS}"
-          echo ::set-output name=build_date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=docker_platforms::${PLATFORMS}
-          echo ::set-output name=push::${PUSH}
-          echo ::set-output name=temp_tag::${TEMP_TAG}
-          echo ::set-output name=final_tags::${FINAL_TAGS[@]}
-          echo "temp_tag=${TEMP_TAG}" >> $GITHUB_OUTPUT
-          echo "final_tags=${FINAL_TAGS[@]}" >> $GITHUB_OUTPUT
-
-      - name: Build and push temporary image
-        working-directory: ./
-        run: |
-          docker buildx create --use
-          docker buildx build --platform ${{ steps.prepare.outputs.docker_platforms }} \
-            --output "type=image,push=${{steps.prepare.outputs.push}}" \
-            --progress=plain \
-            --tag ${{ steps.prepare.outputs.temp_tag }} \
-            -f Dockerfile .
-
-      - name: Debug temp_tag
-        run: |
-          echo "Temporary tag: ${{ steps.prepare.outputs.temp_tag }}"
-
-      - name: Clear DockerHub credentials
-        run: |
-          rm -f ${HOME}/.docker/config.json
   integration-tests:
-    needs: [build, extract-version]
+    needs: [extract-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,9 @@ jobs:
         folder:
           - "packages/node"
       fail-fast: false
+    outputs:
+      temp_tag: ${{ steps.prepare.outputs.temp_tag }}
+      final_tags: ${{ steps.prepare.outputs.final_tags }}
     steps:
       - name: Set up Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
             --tag ${{ steps.prepare.outputs.temp_tag }} \
             -f Dockerfile .
 
-       - name: Clear DockerHub credentials
+      - name: Clear DockerHub credentials
         run: |
           rm -f ${HOME}/.docker/config.json
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,7 +166,6 @@ jobs:
     needs: [integration-tests]
     runs-on: ubuntu-latest
     if: always() && needs.integration-tests.result == 'success'
-
     steps:
       - name: Login into Docker Hub
         env:
@@ -175,23 +174,15 @@ jobs:
         run: |
           echo "${DOCKER_HUB_PASSWORD}" | docker login --username "${DOCKER_HUB_USERNAME}" --password-stdin
 
-      - name: Pull temporary image
-        run: |
-          docker pull ${{ needs.integration-tests.outputs.temp_tag }}
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
 
-      - name: Re-tag image
+      - name: Re-tag and push final tags
         run: |
           TEMP_TAG="${{ needs.integration-tests.outputs.temp_tag }}"
           FINAL_TAGS=(${{ needs.integration-tests.outputs.final_tags }})
           for TAG in "${FINAL_TAGS[@]}"; do
-            docker tag "$TEMP_TAG" "$TAG"
-          done
-
-      - name: Push final tags
-        run: |
-          FINAL_TAGS=(${{ needs.integration-tests.outputs.final_tags }})
-          for TAG in "${FINAL_TAGS[@]}"; do
-            docker push "$TAG"
+            docker buildx imagetools create --tag "$TAG" "$TEMP_TAG"
           done
 
       - name: Clear DockerHub credentials

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           rm -f ${HOME}/.docker/config.json
   integration-tests:
-    needs: [extract-version]
+    needs: [build, extract-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.2",
+  "version": "0.23.0-beta.3",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.6",
+  "version": "0.23.0-beta.7",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.1",
+  "version": "0.23.0-beta.2",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.4",
+  "version": "0.23.0-beta.5",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.8",
+  "version": "0.23.0-beta.0",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.0",
+  "version": "0.23.0-beta.1",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.5",
+  "version": "0.23.0-beta.6",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.10",
+  "version": "0.24.0-beta.0",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.7",
+  "version": "0.23.0-beta.8",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.3",
+  "version": "0.23.0-beta.4",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bitcoin-computer",
-  "version": "0.23.0-beta.0",
+  "version": "0.23.0-beta.10",
   "private": true,
   "description": "A Trustless Smart Contract System for Bitcoin and Litecoin",
   "homepage": "http://bitcoincomputer.io/",

--- a/packages/node/.mocharc.json
+++ b/packages/node/.mocharc.json
@@ -1,9 +1,6 @@
 {
   "extension": ["ts"],
-  "node-option": [
-    "experimental-specifier-resolution=node",
-    "loader=ts-node/esm"
-  ],
+  "node-option": ["experimental-specifier-resolution=node", "loader=ts-node/esm"],
   "require": ["dotenv/config"],
   "spec": "test/*.js",
   "timeout": "30000000"

--- a/packages/node/docker-compose.yml
+++ b/packages/node/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     env_file: .env
     restart: always
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER}" ]
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER}']
     # command: ["postgres", "-c", "log_statement=all"]
     ports:
-      - "${POSTGRES_PORT}:${POSTGRES_PORT}"
+      - '${POSTGRES_PORT}:${POSTGRES_PORT}'
     networks:
       - bcn
     environment:
@@ -28,16 +28,12 @@ services:
       - ./chain-setup/${BCN_CHAIN}/${BCN_NETWORK}/blockchain-data:${BITCOIN_DATA_DIR}
       - ./${BITCOIN_CONF_FILE}:${BITCOIN_DATA_DIR}/${BITCOIN_CONF_FILE}
   bcn:
-    image: bitcoin-computer-node
+    image: bcdb/bcn
     env_file: .env
     restart: always
     build: ../../
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "curl -f http://localhost:${BCN_PORT}/ || exit 1"
-        ]
+      test: ['CMD-SHELL', 'curl -f http://localhost:${BCN_PORT}/ || exit 1']
       interval: 30s
       timeout: 10s
       retries: 3
@@ -69,7 +65,7 @@ services:
       - ./logs:/dist/packages/node/logs
   sync:
     command: npm run start:sync
-    image: bitcoin-computer-node
+    image: bcdb/bcn
     env_file: .env
     restart: always
     environment:

--- a/packages/node/test/test.js
+++ b/packages/node/test/test.js
@@ -16,19 +16,22 @@ describe('Should work with chai', () => {
     expect(computer).an('object')
   })
 
-  it('Should fund the client side library', async () => {
+  it('Should fund the client side library', async function () {
+    this.retries(3)
     const computer = new Computer(conf)
     await computer.faucet(1e7)
     expect((await computer.getBalance()).balance).eq(1e7)
   })
 
-  it('Should send a transaction', async () => {
+  it('Should send a transaction', async function () {
+    this.retries(3)
     const computer = new Computer(conf)
     await computer.faucet(1e7)
-    expect(typeof await computer.send(1e6, new Computer(conf).getAddress())).eq('string')
+    expect(typeof (await computer.send(1e6, new Computer(conf).getAddress()))).eq('string')
   })
 
-  it('Should return the balance of an address', async () => {
+  it('Should return the balance of an address', async function () {
+    this.retries(3)
     const computer = new Computer(conf)
     await computer.faucet(1e7)
     const balance = await new Computer(conf).getBalance(computer.getAddress())
@@ -51,9 +54,9 @@ describe('Should work with chai', () => {
           txId,
           inputsSatoshis: 0,
           outputsSatoshis: 1e7,
-          satoshis: 1e7
-        }
-      ]
+          satoshis: 1e7,
+        },
+      ],
     })
   })
 
@@ -97,9 +100,9 @@ describe('Should work with chai', () => {
           txId,
           inputsSatoshis: 0,
           outputsSatoshis: 1e7,
-          satoshis: 1e7
-        }
-      ]
+          satoshis: 1e7,
+        },
+      ],
     })
   })
 })


### PR DESCRIPTION
Adds workflow on a `tag` push to:
- Build a multiplatform (amd64/arm64) image for bcn service.
- Push temporary to DockerHub
- Run node integration tests over both architectures.
- Push and re-tag to the registry.

The node test now uses retry to avoid timing failures at workflow