### PR TITLE
Track chess games on user profile at deposit and improve game lists UI.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -642,6 +643,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -663,6 +665,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -730,6 +733,7 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -767,6 +771,7 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -834,6 +839,70 @@
         "esbuild": "*"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.24.2",
       "cpu": [
@@ -843,6 +912,343 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -1736,6 +2142,7 @@
       "version": "2.15.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.15.4",
@@ -2071,16 +2478,6 @@
         }
       }
     },
-    "node_modules/@parcel/optimizer-swc/node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@parcel/package-manager": {
       "version": "2.15.4",
       "dev": true,
@@ -2142,16 +2539,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@parcel/package-manager/node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@parcel/packager-css": {
@@ -2923,7 +3310,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3833,6 +4219,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.9.14.tgz",
+      "integrity": "sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@turbo/darwin-arm64": {
       "version": "2.9.14",
       "cpu": [
@@ -3845,11 +4245,66 @@
         "darwin"
       ]
     },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.9.14.tgz",
+      "integrity": "sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.9.14.tgz",
+      "integrity": "sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.9.14.tgz",
+      "integrity": "sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.9.14",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.9.14.tgz",
+      "integrity": "sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3988,6 +4443,7 @@
     "node_modules/@types/node": {
       "version": "20.19.41",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4008,6 +4464,7 @@
     "node_modules/@types/react": {
       "version": "18.3.29",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4098,6 +4555,7 @@
       "version": "8.59.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -4637,6 +5095,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5525,6 +5984,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5716,6 +6176,7 @@
       "version": "5.3.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -6474,7 +6935,8 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1608973",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -6548,8 +7010,7 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6961,6 +7422,7 @@
       "version": "0.24.2",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7046,6 +7508,7 @@
     "node_modules/eslint": {
       "version": "9.29.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7159,6 +7622,7 @@
       "version": "9.1.2",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7267,6 +7731,7 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9743,6 +10208,7 @@
       "version": "2.7.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -9962,7 +10428,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -10150,7 +10615,6 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11615,7 +12079,6 @@
     "node_modules/pg-cursor": {
       "version": "2.20.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "pg": "^8"
       }
@@ -11735,6 +12198,7 @@
     "node_modules/picomatch": {
       "version": "4.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11842,6 +12306,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -11973,6 +12438,7 @@
     "node_modules/prettier": {
       "version": "3.8.3",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11997,7 +12463,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12011,7 +12476,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12022,8 +12486,7 @@
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -12300,6 +12763,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12366,6 +12830,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12715,6 +13180,7 @@
       "version": "4.60.4",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12970,6 +13436,7 @@
       "version": "8.20.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13978,6 +14445,7 @@
       "version": "1.21.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -14565,6 +15033,74 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
       "version": "0.28.0",
       "cpu": [
@@ -14576,7 +15112,346 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -14763,6 +15638,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14984,6 +15860,7 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -15087,6 +15964,74 @@
         "vite": ">=2.6.0"
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
       "cpu": [
@@ -15097,6 +16042,312 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -15297,6 +16548,7 @@
       "version": "4.10.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -15919,6 +17171,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -16440,6 +17693,7 @@
       "version": "19.2.15",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -16473,6 +17727,7 @@
     "packages/nextjs-template/node_modules/react": {
       "version": "19.2.6",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/packages/chess-app/src/components/ChessBoard.tsx
+++ b/packages/chess-app/src/components/ChessBoard.tsx
@@ -27,7 +27,7 @@ import { Piece } from 'react-chessboard/dist/chessboard/types'
 import { CreateUserModal, creaetUserModal } from './CreateUser'
 import { ChallengeListWrapper } from './ChallengesListWrapper'
 import { Computer, SmartContract } from '@bitcoin-computer/lib'
-import { GamesListWrapper } from './GamesListWrapper'
+import { ActiveTurnsList, GameListsProvider, MyGamesList } from './GamesListWrapper'
 
 const winnerModal = 'winner-modal'
 
@@ -670,12 +670,17 @@ export function ChessBoard() {
           >
             New Game
           </button>
-          <div>
-            <GamesListWrapper setGameId={setGameId} setUser={setUser} />
-          </div>
-          <div>
-            <ChallengeListWrapper user={user} />
-          </div>
+          <GameListsProvider setUser={setUser}>
+            <div>
+              <ActiveTurnsList setGameId={setGameId} />
+            </div>
+            <div>
+              <ChallengeListWrapper user={user} />
+            </div>
+            <div>
+              <MyGamesList setGameId={setGameId} />
+            </div>
+          </GameListsProvider>
         </div>
 
         {/* Chessboard Column */}

--- a/packages/chess-app/src/components/GamesList.tsx
+++ b/packages/chess-app/src/components/GamesList.tsx
@@ -11,10 +11,14 @@ export const InfiniteScroll = ({
   setGameId,
   games,
   refreshGames,
+  title,
+  showNewBadge = true,
 }: {
   setGameId: React.Dispatch<React.SetStateAction<string>>
   games: GameType[]
   refreshGames: () => Promise<void>
+  title: string
+  showNewBadge?: boolean
 }) => {
   const [items, setItems] = useState<GameType[]>([])
   const [hasMore, setHasMore] = useState(true)
@@ -69,7 +73,7 @@ export const InfiniteScroll = ({
       <div className="flex justify-center mt-2 mb-2">
         <h3 className="text-xl font-bold text-gray-500 dark:text-gray-400">
           <span className="hover:text-gray-700 dark:hover:text-gray-200 font-extrabold cursor-pointer">
-            My Games
+            {title}
           </span>{' '}
           <HiRefresh
             onClick={refreshGames}
@@ -95,7 +99,7 @@ export const InfiniteScroll = ({
               }}
             >
               <span className="truncate block">{item.gameId}</span>
-              {item.new && (
+              {showNewBadge && item.new && (
                 <div className="absolute inline-flex w-3 h-3 bg-red-500 rounded-full top-0 right-0 -mt-1 -mr-1 z-10"></div>
               )}
             </li>

--- a/packages/chess-app/src/components/GamesListWrapper.tsx
+++ b/packages/chess-app/src/components/GamesListWrapper.tsx
@@ -1,39 +1,61 @@
 import { ChessContract, User } from '@bitcoin-computer/chess-contracts'
 import { ComputerContext } from '@bitcoin-computer/components'
-import { useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { VITE_CHESS_GAME_MOD_SPEC, VITE_CHESS_USER_MOD_SPEC } from '../constants/modSpecs'
 
 import { GameType, InfiniteScroll } from './GamesList'
-import { SmartContract } from '@bitcoin-computer/lib'
+import { CHESS_GAMES_UPDATED } from './utils/gamesRefresh'
+import { isFullyFunded, isMyActiveTurn } from './utils'
 
-export const GamesListWrapper = ({
-  setGameId,
+type GameListsContextValue = {
+  activeTurns: GameType[]
+  myGames: GameType[]
+  refreshGames: () => Promise<void>
+}
+
+const GameListsContext = createContext<GameListsContextValue | null>(null)
+
+function useGameListsContext() {
+  const value = useContext(GameListsContext)
+  if (!value) {
+    throw new Error('Game list components must be used within GameListsProvider')
+  }
+  return value
+}
+
+export function GameListsProvider({
+  children,
   setUser,
 }: {
-  setGameId: React.Dispatch<React.SetStateAction<string>>
+  children: ReactNode
   setUser: React.Dispatch<React.SetStateAction<User | null>>
-}) => {
+}) {
   const computer = useContext(ComputerContext)
-  const [games, setGames] = useState<GameType[]>([])
+  const [activeTurns, setActiveTurns] = useState<GameType[]>([])
+  const [myGames, setMyGames] = useState<GameType[]>([])
 
   const getLatestGames = async () => {
-    const availableGames: GameType[] = []
+    const activeTurnGames: GameType[] = []
+    const userGames: GameType[] = []
+
     const gameRevs = await computer.getOUTXOs({
       mod: VITE_CHESS_GAME_MOD_SPEC,
       publicKey: computer.getPublicKey(),
     })
 
-    const gameSyncPromises: Promise<SmartContract<typeof ChessContract>>[] = []
+    const gamesList = await Promise.all(
+      gameRevs.map((rev) => computer.sync<typeof ChessContract>(rev)),
+    )
 
-    gameRevs.forEach((rev) => {
-      gameSyncPromises.push(computer.sync<typeof ChessContract>(rev))
-    })
-
-    const gamesList = await Promise.all(gameSyncPromises)
+    const myPubKey = computer.getPublicKey()
 
     gamesList.forEach((game) => {
-      if (game.sans && game.sans.length === 0) {
-        availableGames.push({ gameId: game._id, new: !game.canceledSeen })
+      if (isMyActiveTurn(game, myPubKey)) {
+        const isPending = !isFullyFunded(game)
+        activeTurnGames.push({
+          gameId: game._id,
+          new: isPending && !game.canceledSeen,
+        })
       }
     })
 
@@ -44,50 +66,102 @@ export const GamesListWrapper = ({
 
     if (userRev) {
       const userObj = await computer.sync<typeof User>(userRev)
-      userObj.games.forEach((gameObjId) => {
-        availableGames.push({ gameId: gameObjId, new: false })
+      const latestUserRev = await computer.latest(userObj._id)
+      const latestUser = await computer.sync<typeof User>(latestUserRev)
+      latestUser.games.forEach((gameObjId) => {
+        userGames.push({ gameId: gameObjId, new: false })
       })
-      setUser(userObj)
+      setUser(latestUser)
     }
 
-    return availableGames
+    return { activeTurnGames, userGames }
   }
+
   const refreshGames = async () => {
-    const availableGames: GameType[] = await getLatestGames()
-    setGames(availableGames)
+    const { activeTurnGames, userGames } = await getLatestGames()
+    setActiveTurns(activeTurnGames)
+    setMyGames(userGames)
   }
 
   useEffect(() => {
-    // Initial fetch without relying on scroll
-    const fetch = async () => {
-      const availableGames: GameType[] = await getLatestGames()
-      setGames(availableGames)
-    }
-    fetch()
+    refreshGames()
   }, [])
 
   useEffect(() => {
-    let unsubscribe: (() => void) | undefined
+    const onGamesUpdated = () => {
+      refreshGames()
+    }
+    window.addEventListener(CHESS_GAMES_UPDATED, onGamesUpdated)
+    return () => window.removeEventListener(CHESS_GAMES_UPDATED, onGamesUpdated)
+  }, [])
+
+  useEffect(() => {
+    let unsubscribeGame: (() => void) | undefined
+    let unsubscribeUser: (() => void) | undefined
 
     const subscribe = async () => {
-      unsubscribe = await computer.streamTXOs(
+      unsubscribeGame = await computer.streamTXOs(
         { mod: VITE_CHESS_GAME_MOD_SPEC, publicKey: computer.getPublicKey() },
         () => {
           refreshGames()
         },
         (err) => console.error('Game stream error:', err),
       )
+      unsubscribeUser = await computer.streamTXOs(
+        { mod: VITE_CHESS_USER_MOD_SPEC, publicKey: computer.getPublicKey() },
+        () => {
+          refreshGames()
+        },
+        (err) => console.error('User stream error:', err),
+      )
     }
     subscribe()
 
     return () => {
-      if (unsubscribe) unsubscribe()
+      if (unsubscribeGame) unsubscribeGame()
+      if (unsubscribeUser) unsubscribeUser()
     }
   }, [computer])
 
   return (
-    <>
-      <InfiniteScroll games={games} refreshGames={refreshGames} setGameId={setGameId} />
-    </>
+    <GameListsContext.Provider value={{ activeTurns, myGames, refreshGames }}>
+      {children}
+    </GameListsContext.Provider>
+  )
+}
+
+export function ActiveTurnsList({
+  setGameId,
+}: {
+  setGameId: React.Dispatch<React.SetStateAction<string>>
+}) {
+  const { activeTurns, refreshGames } = useGameListsContext()
+
+  return (
+    <InfiniteScroll
+      title="My Active Turns"
+      games={activeTurns}
+      refreshGames={refreshGames}
+      setGameId={setGameId}
+      showNewBadge
+    />
+  )
+}
+
+export function MyGamesList({
+  setGameId,
+}: {
+  setGameId: React.Dispatch<React.SetStateAction<string>>
+}) {
+  const { myGames, refreshGames } = useGameListsContext()
+
+  return (
+    <InfiniteScroll
+      title="My Games"
+      games={myGames}
+      refreshGames={refreshGames}
+      setGameId={setGameId}
+      showNewBadge={false}
+    />
   )
 }

--- a/packages/chess-app/src/components/NewGame.tsx
+++ b/packages/chess-app/src/components/NewGame.tsx
@@ -10,6 +10,7 @@ import {
   VITE_CHESS_USER_MOD_SPEC,
   VITE_TBC20_MOD_SPEC,
 } from '../constants/modSpecs'
+import { notifyGamesUpdated } from './utils/gamesRefresh'
 
 export const newGameModal = 'new-game-modal'
 
@@ -60,6 +61,7 @@ function NewGameModalContent({
 
       // White deposits their wager atomically with the game creation step
       await helper.depositTokens(chess._rev, token._rev, wager, nameW, publicKeyB)
+      await helper.addGameToUserIfNeeded(chess._id)
 
       // Create a challenge so Black can find and accept the game
       const chessChallengeTxWrapperHelper = new ChessChallengeTxWrapperHelper({
@@ -75,6 +77,7 @@ function NewGameModalContent({
       )
 
       showSnackBar('Challenge sent! Waiting for opponent to accept.', true)
+      notifyGamesUpdated()
       Modal.hideModal(newGameModal)
       handleClear()
     } catch (err) {

--- a/packages/chess-app/src/components/StartGame.tsx
+++ b/packages/chess-app/src/components/StartGame.tsx
@@ -13,6 +13,7 @@ import {
 } from '../constants/modSpecs'
 import { SmartContract } from '@bitcoin-computer/lib'
 import { isCreatorRefunded } from './utils'
+import { notifyGamesUpdated } from './utils/gamesRefresh'
 
 export const startGameModal = 'start-game-modal'
 
@@ -63,6 +64,7 @@ export function StartGameModalContent({
         'Black',
         challenge.publicKeyW,
       )
+      await helper.addGameToUserIfNeeded(chess._id)
 
       // Mark challenge as accepted
       try {
@@ -72,6 +74,7 @@ export function StartGameModalContent({
       }
 
       Modal.hideModal(startGameModal)
+      notifyGamesUpdated()
       navigate(`/game/${chess._id}`)
     } catch (err) {
       showSnackBar(err instanceof Error ? err.message : 'Error occurred!', false)

--- a/packages/chess-app/src/components/utils/gamesRefresh.ts
+++ b/packages/chess-app/src/components/utils/gamesRefresh.ts
@@ -1,0 +1,5 @@
+export const CHESS_GAMES_UPDATED = 'chess-games-updated'
+
+export function notifyGamesUpdated() {
+  window.dispatchEvent(new Event(CHESS_GAMES_UPDATED))
+}

--- a/packages/chess-app/src/components/utils/index.ts
+++ b/packages/chess-app/src/components/utils/index.ts
@@ -16,6 +16,24 @@ export async function isCreatorRefunded(
   }
 }
 
+export function isFullyFunded(chessContract: SmartContract<typeof ChessContract>): boolean {
+  return !!chessContract.publicKeyW && !!chessContract.publicKeyB
+}
+
+export function isGamePlayable(chessContract: SmartContract<typeof ChessContract>): boolean {
+  if (chessContract.withdraws.length > 0) return false
+  if (!isFullyFunded(chessContract)) return true
+  return !new ChessLib(chessContract.fen).isGameOver()
+}
+
+export function isMyActiveTurn(
+  chessContract: SmartContract<typeof ChessContract>,
+  pubKey: string,
+): boolean {
+  if (!isGamePlayable(chessContract)) return false
+  return chessContract._owners[0] === pubKey
+}
+
 export function getGameState(chessContract: SmartContract<typeof ChessContract>): string {
   if (!chessContract) return 'In Progress'
 

--- a/packages/chess-app/vite.config.ts
+++ b/packages/chess-app/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     optimizeDeps: {
+      exclude: ['@bitcoin-computer/chess-contracts'],
       esbuildOptions: {
         define: {
           global: 'globalThis',

--- a/packages/chess-contracts/src/chess-contract.ts
+++ b/packages/chess-contracts/src/chess-contract.ts
@@ -241,6 +241,30 @@ export class ChessContractHelper {
     }
   }
 
+  async addGameToUserIfNeeded(gameId: string): Promise<void> {
+    if (!this.userMod || !gameId) return
+    const [userRev] = await this.computer.getOUTXOs({
+      mod: this.userMod,
+      publicKey: this.computer.getPublicKey(),
+    })
+    if (!userRev) return
+    const userObj = await this.computer.sync<typeof User>(userRev)
+    if (userObj.games.includes(gameId)) return
+
+    const latestUserRev = await this.computer.latest(userObj._id)
+    const latestUser = await this.computer.sync<typeof User>(latestUserRev)
+    if (latestUser.games.includes(gameId)) return
+
+    const { tx } = await this.computer.encodeCall({
+      target: latestUser,
+      property: 'addGame',
+      args: [gameId],
+      mod: this.userMod,
+    })
+    if (!tx) throw new Error('Failed to record game on user profile')
+    await this.computer.broadcast(tx)
+  }
+
   async createGame(
     tokenRoot: string,
     wagerAmount: bigint,
@@ -276,7 +300,10 @@ export class ChessContractHelper {
       await coSignComputer.sign(tx)
     }
     await this.computer.broadcast(tx)
-    return effect.env.chess as SmartContract<typeof ChessContract>
+    const chess = effect.env.chess as SmartContract<typeof ChessContract>
+    const gameId = chess._id ?? chess._root
+    await this.addGameToUserIfNeeded(gameId)
+    return chess
   }
 
   async findToken(
@@ -304,17 +331,7 @@ export class ChessContractHelper {
     promotion: string,
   ): Promise<{ newChessContract: SmartContract<typeof ChessContract>; isGameOver: boolean }> {
     if (chessContract && chessContract.sans.length < 2) {
-      const [userRev] = await this.computer.getOUTXOs({
-        mod: this.userMod,
-        publicKey: this.computer.getPublicKey(),
-      })
-      if (userRev) {
-        const userObj = await this.computer.sync<typeof User>(userRev)
-        const gameId = chessContract._id
-        if (!userObj.games.includes(gameId)) {
-          await userObj.addGame(gameId)
-        }
-      }
+      await this.addGameToUserIfNeeded(chessContract._id)
     }
 
     const { tx, effect } = (await this.computer.encodeCall({

--- a/packages/chess-contracts/test/chess-contract.test.ts
+++ b/packages/chess-contracts/test/chess-contract.test.ts
@@ -2,7 +2,7 @@ import { Computer, SmartContract } from '@bitcoin-computer/lib'
 import { EscrowAuditor, TBC20, TBC777 } from '@bitcoin-computer/TBC777'
 import { ChessContract, ChessContractHelper } from '../src/chess-contract.js'
 import { ChessChallengeTxWrapper } from '../src/chess-challenge.js'
-import { User } from '../src/user.js'
+import { User, UserHelper } from '../src/user.js'
 import { expect } from 'expect'
 import dotenv from 'dotenv'
 import path from 'path'
@@ -499,16 +499,12 @@ describe('ChessContract', () => {
           5n,
         )
 
-        const blackTokenFinal = await withdrawFromChess(
-          black,
-          blackToken._id,
-          chess._id,
-          tbc777Mod,
-        )
+        const blackTokenFinal = await withdrawFromChess(black, blackToken._id, chess._id, tbc777Mod)
         expect(blackTokenFinal.amount).toBe(15n)
       })
 
       it('Should run fool mate and credit winner balance on withdraw', async () => {
+        await confirmChainTip(minter)
         const wager = 5n
         const timeLimit = 60n * 10n
         const { token, whiteTokenUtxo, blackTokenUtxo, blackToken, chess, chessFunded } =
@@ -555,13 +551,198 @@ describe('ChessContract', () => {
         const totalPot = wager * 2n
         expect(chessFinal.withdraws).toEqual([[token._root, blackToken._id, totalPot]])
 
-        const blackTokenFinal = await withdrawFromChess(
-          black,
-          blackToken._id,
-          chess._id,
+        const blackTokenFinal = await withdrawFromChess(black, blackToken._id, chess._id, tbc777Mod)
+        expect(blackTokenFinal.amount).toBe(15n)
+      })
+    })
+
+    describe('User.games on deposit', () => {
+      let minter: Computer
+      let white: Computer
+      let black: Computer
+      let userMod: string
+
+      before(async () => {
+        const deployer = new Computer({ url, chain, network })
+        await deployer.faucet(20e8)
+        userMod = await deployer.deploy(`export ${User}`)
+      })
+
+      beforeEach(async () => {
+        minter = new Computer({ url, chain, network })
+        white = new Computer({ url, chain, network })
+        black = new Computer({ url, chain, network })
+        await Promise.all([white.faucet(10e8), black.faucet(10e8), minter.faucet(10e8)])
+        await ensureFunds(minter)
+
+        const whiteUserHelper = new UserHelper({ computer: white, mod: userMod })
+        const blackUserHelper = new UserHelper({ computer: black, mod: userMod })
+        await whiteUserHelper.createUser('White')
+        await blackUserHelper.createUser('Black')
+        await confirmChainTip(minter)
+      })
+
+      async function syncUser(player: Computer) {
+        const [userRev] = await player.getOUTXOs({
+          mod: userMod,
+          publicKey: player.getPublicKey(),
+        })
+        if (!userRev) throw new Error('expected user account')
+        return player.sync<typeof User>(userRev)
+      }
+
+      it('Should add the game to white user on first deposit', async () => {
+        const wager = 5n
+        const timeLimit = 60n * 10n
+        const to = minter.getPublicKey()
+        const token = await minter.new(
+          TBC777,
+          [{ to, amount: 20n, name: 'chess', symbol: TOKEN_SYMBOL }],
           tbc777Mod,
         )
-        expect(blackTokenFinal.amount).toBe(15n)
+        await confirmChainTip(minter)
+        const whiteTokenUtxo = await token.transfer(white.getPublicKey(), 10n)
+        if (!whiteTokenUtxo) throw new Error('expected white token UTXO')
+
+        const helper = ChessContractHelper.fromModSpecs(white, chessMod, userMod, tbc777Mod)
+        const chess = await helper.createGame(token._root, wager, timeLimit)
+        await helper.depositTokens(
+          chess._rev,
+          whiteTokenUtxo._rev,
+          wager,
+          'White',
+          black.getPublicKey(),
+        )
+        await confirmChainTip(minter)
+
+        const whiteUser = await syncUser(white)
+        expect(whiteUser.games).toEqual([chess._id])
+      })
+
+      it('Should add the game to both users after both deposits', async () => {
+        const wager = 5n
+        const timeLimit = 60n * 10n
+        const to = minter.getPublicKey()
+        const token = await minter.new(
+          TBC777,
+          [{ to, amount: 20n, name: 'chess', symbol: TOKEN_SYMBOL }],
+          tbc777Mod,
+        )
+        await confirmChainTip(minter)
+        const whiteTokenUtxo = await token.transfer(white.getPublicKey(), 10n)
+        await confirmChainTip(minter)
+        const blackTokenUtxo = await token.transfer(black.getPublicKey(), 10n)
+        await confirmChainTip(minter)
+        if (!whiteTokenUtxo || !blackTokenUtxo) throw new Error('expected player token UTXOs')
+
+        const whiteHelper = ChessContractHelper.fromModSpecs(white, chessMod, userMod, tbc777Mod)
+        const blackHelper = ChessContractHelper.fromModSpecs(black, chessMod, userMod, tbc777Mod)
+
+        const chess = await whiteHelper.createGame(token._root, wager, timeLimit)
+        const chessAfterWhite = await whiteHelper.depositTokens(
+          chess._rev,
+          whiteTokenUtxo._rev,
+          wager,
+          'White',
+          black.getPublicKey(),
+        )
+        await confirmChainTip(minter)
+
+        const whiteUserAfterDeposit = await syncUser(white)
+        expect(whiteUserAfterDeposit.games).toEqual([chess._id])
+
+        const blackToken = await black.sync<typeof TBC777>(blackTokenUtxo._rev)
+        const chessHeadForBlack = await white.latest(chessAfterWhite._id)
+        await blackHelper.depositTokens(
+          chessHeadForBlack,
+          blackToken._rev,
+          wager,
+          'Black',
+          white.getPublicKey(),
+        )
+        await confirmChainTip(minter)
+
+        const whiteUser = await syncUser(white)
+        const blackUser = await syncUser(black)
+        expect(whiteUser.games).toEqual([chess._id])
+        expect(blackUser.games).toEqual([chess._id])
+      })
+
+      it('Should not duplicate game ids when addGameToUserIfNeeded is called twice', async () => {
+        const wager = 5n
+        const timeLimit = 60n * 10n
+        const to = minter.getPublicKey()
+        const token = await minter.new(
+          TBC777,
+          [{ to, amount: 20n, name: 'chess', symbol: TOKEN_SYMBOL }],
+          tbc777Mod,
+        )
+        await confirmChainTip(minter)
+        const whiteTokenUtxo = await token.transfer(white.getPublicKey(), 10n)
+        if (!whiteTokenUtxo) throw new Error('expected white token UTXO')
+
+        const helper = ChessContractHelper.fromModSpecs(white, chessMod, userMod, tbc777Mod)
+        const chess = await helper.createGame(token._root, wager, timeLimit)
+        await helper.depositTokens(
+          chess._rev,
+          whiteTokenUtxo._rev,
+          wager,
+          'White',
+          black.getPublicKey(),
+        )
+        await confirmChainTip(minter)
+        await helper.addGameToUserIfNeeded(chess._id)
+        await confirmChainTip(minter)
+
+        const whiteUser = await syncUser(white)
+        expect(whiteUser.games).toEqual([chess._id])
+      })
+
+      it('Should not duplicate game ids when move runs after deposit', async () => {
+        const wager = 5n
+        const timeLimit = 60n * 10n
+        const to = minter.getPublicKey()
+        const token = await minter.new(
+          TBC777,
+          [{ to, amount: 20n, name: 'chess', symbol: TOKEN_SYMBOL }],
+          tbc777Mod,
+        )
+        await confirmChainTip(minter)
+        const whiteTokenUtxo = await token.transfer(white.getPublicKey(), 10n)
+        await confirmChainTip(minter)
+        const blackTokenUtxo = await token.transfer(black.getPublicKey(), 10n)
+        await confirmChainTip(minter)
+        if (!whiteTokenUtxo || !blackTokenUtxo) throw new Error('expected player token UTXOs')
+
+        const whiteHelper = ChessContractHelper.fromModSpecs(white, chessMod, userMod, tbc777Mod)
+        const blackHelper = ChessContractHelper.fromModSpecs(black, chessMod, userMod, tbc777Mod)
+
+        const chess = await whiteHelper.createGame(token._root, wager, timeLimit)
+        const chessAfterWhite = await whiteHelper.depositTokens(
+          chess._rev,
+          whiteTokenUtxo._rev,
+          wager,
+          'White',
+          black.getPublicKey(),
+        )
+        await confirmChainTip(minter)
+
+        const blackToken = await black.sync<typeof TBC777>(blackTokenUtxo._rev)
+        const chessHeadForBlack = await white.latest(chessAfterWhite._id)
+        const chessFunded = await blackHelper.depositTokens(
+          chessHeadForBlack,
+          blackToken._rev,
+          wager,
+          'Black',
+          white.getPublicKey(),
+        )
+        await confirmChainTip(minter)
+
+        await whiteHelper.move(chessFunded, 'e2', 'e4', 'q')
+        await confirmChainTip(minter)
+
+        const whiteUser = await syncUser(white)
+        expect(whiteUser.games).toEqual([chess._id])
       })
     })
   })


### PR DESCRIPTION
## Summary

- Add `ChessContractHelper.addGameToUserIfNeeded` and call it from `depositTokens` (and refactor `move` to use it), so games are recorded on the user profile when a player deposits rather than only on the first move.
- Refactor the chess-app sidebar into separate **My Active Turns** and **My Games** lists via `GameListsProvider`, with TXO streaming on both game and user mods plus a `chess-games-updated` event for cross-component refresh after new/accepted games.
- Add contract tests covering `User.games` population on deposit, both-player deposits, and deduplication when `addGameToUserIfNeeded` or `move` runs after deposit.
- Exclude `@bitcoin-computer/chess-contracts` from Vite `optimizeDeps`.